### PR TITLE
feat(change-password): Implement specialist password change with sess…

### DIFF
--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -22,7 +22,7 @@ import (
 // @host   petbackend-a2vg.onrender.com
 // @BasePath  /api/v1/
 
-// @schemes http https
+// @schemes https http
 
 // @securityDefinitions.apikey BearerAuth
 // @in header

--- a/docs/docs.go
+++ b/docs/docs.go
@@ -100,6 +100,69 @@ const docTemplate = `{
                 }
             }
         },
+        "/specialist/change-password": {
+            "patch": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Allows an authenticated specialist to change their password. All active sessions will be terminated upon successful password change.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Specialist"
+                ],
+                "summary": "Change specialist password",
+                "parameters": [
+                    {
+                        "description": "Change password request",
+                        "name": "request",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/domain.ChangePassReq"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Password updated successfully",
+                        "schema": {
+                            "$ref": "#/definitions/domain.SuccessResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Invalid request payload or validation failed",
+                        "schema": {
+                            "$ref": "#/definitions/domain.ErrorResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized or invalid old password",
+                        "schema": {
+                            "$ref": "#/definitions/domain.ErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Specialist account not found",
+                        "schema": {
+                            "$ref": "#/definitions/domain.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal server error",
+                        "schema": {
+                            "$ref": "#/definitions/domain.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
         "/specialist/login": {
             "post": {
                 "description": "Login specialist",
@@ -120,7 +183,7 @@ const docTemplate = `{
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/handlers.LoginReq"
+                            "$ref": "#/definitions/domain.LoginReq"
                         }
                     }
                 ],
@@ -320,6 +383,27 @@ const docTemplate = `{
                 }
             }
         },
+        "domain.ChangePassReq": {
+            "description": "Change password request payload",
+            "type": "object",
+            "required": [
+                "current_password",
+                "new_password"
+            ],
+            "properties": {
+                "current_password": {
+                    "description": "The specialist's current password.\nrequired: true\nexample: MySecretPassword123!",
+                    "type": "string",
+                    "example": "MySecretPassword123!"
+                },
+                "new_password": {
+                    "description": "The new password for the specialist account.\nMust be at least 12 characters long.\nMust contain at least one uppercase letter, one lowercase letter, one number, and one special character from @$!%*?\u0026.\nrequired: true\nminLength: 12\nmaxLength: 255\npattern: \"^(?=.*[a-z])(?=.*[A-Z])(?=.*\\\\d)(?=.*[@$!%*?\u0026])[A-Za-z\\\\d@$!%*?\u0026]{12,255}$\"\nexample: NewStr0ngP@ssw0rd!",
+                    "type": "string",
+                    "minLength": 12,
+                    "example": "NewStr0ngP@ssw0rd!"
+                }
+            }
+        },
         "domain.ErrorResponse": {
             "type": "object",
             "properties": {
@@ -349,6 +433,26 @@ const docTemplate = `{
                 "message": {
                     "type": "string",
                     "example": "This field is required."
+                }
+            }
+        },
+        "domain.LoginReq": {
+            "description": "User login request payload",
+            "type": "object",
+            "required": [
+                "email",
+                "password"
+            ],
+            "properties": {
+                "email": {
+                    "description": "Email address of the user.\nrequired: true\nformat: email\nexample: user@example.com",
+                    "type": "string",
+                    "example": "user@example.com"
+                },
+                "password": {
+                    "description": "Password for the user account.\nrequired: true\nexample: MySecretPassword123!",
+                    "type": "string",
+                    "example": "MySecretPassword123!"
                 }
             }
         },
@@ -449,6 +553,19 @@ const docTemplate = `{
                 }
             }
         },
+        "domain.SuccessResponse": {
+            "type": "object",
+            "properties": {
+                "code": {
+                    "type": "integer",
+                    "example": 200
+                },
+                "message": {
+                    "type": "string",
+                    "example": "Operation was successful"
+                }
+            }
+        },
         "domain.TokensPair": {
             "type": "object",
             "properties": {
@@ -457,26 +574,6 @@ const docTemplate = `{
                 },
                 "refresh_token": {
                     "type": "string"
-                }
-            }
-        },
-        "handlers.LoginReq": {
-            "description": "User login request payload",
-            "type": "object",
-            "required": [
-                "email",
-                "password"
-            ],
-            "properties": {
-                "email": {
-                    "description": "Email address of the user.\nrequired: true\nformat: email\nexample: user@example.com",
-                    "type": "string",
-                    "example": "user@example.com"
-                },
-                "password": {
-                    "description": "Password for the user account.\nrequired: true\nexample: MySecretPassword123!",
-                    "type": "string",
-                    "example": "MySecretPassword123!"
                 }
             }
         },
@@ -524,7 +621,7 @@ var SwaggerInfo = &swag.Spec{
 	Version:          "1.0",
 	Host:             "petbackend-a2vg.onrender.com",
 	BasePath:         "/api/v1/",
-	Schemes:          []string{"http", "https"},
+	Schemes:          []string{"https", "http"},
 	Title:            "Swagger Example API",
 	Description:      "This is a PetHelp project backend",
 	InfoInstanceName: "swagger",

--- a/docs/docs.go
+++ b/docs/docs.go
@@ -154,6 +154,12 @@ const docTemplate = `{
                             "$ref": "#/definitions/domain.ErrorResponse"
                         }
                     },
+                    "409": {
+                        "description": "Conflict: New password is the same as the old one",
+                        "schema": {
+                            "$ref": "#/definitions/domain.ErrorResponse"
+                        }
+                    },
                     "500": {
                         "description": "Internal server error",
                         "schema": {

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -152,6 +152,12 @@
                             "$ref": "#/definitions/domain.ErrorResponse"
                         }
                     },
+                    "409": {
+                        "description": "Conflict: New password is the same as the old one",
+                        "schema": {
+                            "$ref": "#/definitions/domain.ErrorResponse"
+                        }
+                    },
                     "500": {
                         "description": "Internal server error",
                         "schema": {

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -1,7 +1,7 @@
 {
     "schemes": [
-        "http",
-        "https"
+        "https",
+        "http"
     ],
     "swagger": "2.0",
     "info": {
@@ -98,6 +98,69 @@
                 }
             }
         },
+        "/specialist/change-password": {
+            "patch": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Allows an authenticated specialist to change their password. All active sessions will be terminated upon successful password change.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Specialist"
+                ],
+                "summary": "Change specialist password",
+                "parameters": [
+                    {
+                        "description": "Change password request",
+                        "name": "request",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/domain.ChangePassReq"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Password updated successfully",
+                        "schema": {
+                            "$ref": "#/definitions/domain.SuccessResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Invalid request payload or validation failed",
+                        "schema": {
+                            "$ref": "#/definitions/domain.ErrorResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized or invalid old password",
+                        "schema": {
+                            "$ref": "#/definitions/domain.ErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Specialist account not found",
+                        "schema": {
+                            "$ref": "#/definitions/domain.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal server error",
+                        "schema": {
+                            "$ref": "#/definitions/domain.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
         "/specialist/login": {
             "post": {
                 "description": "Login specialist",
@@ -118,7 +181,7 @@
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/handlers.LoginReq"
+                            "$ref": "#/definitions/domain.LoginReq"
                         }
                     }
                 ],
@@ -318,6 +381,27 @@
                 }
             }
         },
+        "domain.ChangePassReq": {
+            "description": "Change password request payload",
+            "type": "object",
+            "required": [
+                "current_password",
+                "new_password"
+            ],
+            "properties": {
+                "current_password": {
+                    "description": "The specialist's current password.\nrequired: true\nexample: MySecretPassword123!",
+                    "type": "string",
+                    "example": "MySecretPassword123!"
+                },
+                "new_password": {
+                    "description": "The new password for the specialist account.\nMust be at least 12 characters long.\nMust contain at least one uppercase letter, one lowercase letter, one number, and one special character from @$!%*?\u0026.\nrequired: true\nminLength: 12\nmaxLength: 255\npattern: \"^(?=.*[a-z])(?=.*[A-Z])(?=.*\\\\d)(?=.*[@$!%*?\u0026])[A-Za-z\\\\d@$!%*?\u0026]{12,255}$\"\nexample: NewStr0ngP@ssw0rd!",
+                    "type": "string",
+                    "minLength": 12,
+                    "example": "NewStr0ngP@ssw0rd!"
+                }
+            }
+        },
         "domain.ErrorResponse": {
             "type": "object",
             "properties": {
@@ -347,6 +431,26 @@
                 "message": {
                     "type": "string",
                     "example": "This field is required."
+                }
+            }
+        },
+        "domain.LoginReq": {
+            "description": "User login request payload",
+            "type": "object",
+            "required": [
+                "email",
+                "password"
+            ],
+            "properties": {
+                "email": {
+                    "description": "Email address of the user.\nrequired: true\nformat: email\nexample: user@example.com",
+                    "type": "string",
+                    "example": "user@example.com"
+                },
+                "password": {
+                    "description": "Password for the user account.\nrequired: true\nexample: MySecretPassword123!",
+                    "type": "string",
+                    "example": "MySecretPassword123!"
                 }
             }
         },
@@ -447,6 +551,19 @@
                 }
             }
         },
+        "domain.SuccessResponse": {
+            "type": "object",
+            "properties": {
+                "code": {
+                    "type": "integer",
+                    "example": 200
+                },
+                "message": {
+                    "type": "string",
+                    "example": "Operation was successful"
+                }
+            }
+        },
         "domain.TokensPair": {
             "type": "object",
             "properties": {
@@ -455,26 +572,6 @@
                 },
                 "refresh_token": {
                     "type": "string"
-                }
-            }
-        },
-        "handlers.LoginReq": {
-            "description": "User login request payload",
-            "type": "object",
-            "required": [
-                "email",
-                "password"
-            ],
-            "properties": {
-                "email": {
-                    "description": "Email address of the user.\nrequired: true\nformat: email\nexample: user@example.com",
-                    "type": "string",
-                    "example": "user@example.com"
-                },
-                "password": {
-                    "description": "Password for the user account.\nrequired: true\nexample: MySecretPassword123!",
-                    "type": "string",
-                    "example": "MySecretPassword123!"
                 }
             }
         },

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -9,6 +9,33 @@ definitions:
         example: "2023-10-27T10:00:00Z"
         type: string
     type: object
+  domain.ChangePassReq:
+    description: Change password request payload
+    properties:
+      current_password:
+        description: |-
+          The specialist's current password.
+          required: true
+          example: MySecretPassword123!
+        example: MySecretPassword123!
+        type: string
+      new_password:
+        description: |-
+          The new password for the specialist account.
+          Must be at least 12 characters long.
+          Must contain at least one uppercase letter, one lowercase letter, one number, and one special character from @$!%*?&.
+          required: true
+          minLength: 12
+          maxLength: 255
+          pattern: "^(?=.*[a-z])(?=.*[A-Z])(?=.*\\d)(?=.*[@$!%*?&])[A-Za-z\\d@$!%*?&]{12,255}$"
+          example: NewStr0ngP@ssw0rd!
+        example: NewStr0ngP@ssw0rd!
+        minLength: 12
+        type: string
+    required:
+    - current_password
+    - new_password
+    type: object
   domain.ErrorResponse:
     properties:
       code:
@@ -30,6 +57,28 @@ definitions:
       message:
         example: This field is required.
         type: string
+    type: object
+  domain.LoginReq:
+    description: User login request payload
+    properties:
+      email:
+        description: |-
+          Email address of the user.
+          required: true
+          format: email
+          example: user@example.com
+        example: user@example.com
+        type: string
+      password:
+        description: |-
+          Password for the user account.
+          required: true
+          example: MySecretPassword123!
+        example: MySecretPassword123!
+        type: string
+    required:
+    - email
+    - password
     type: object
   domain.RegistrationRequest:
     description: User registration request payload
@@ -163,34 +212,21 @@ definitions:
           example: Veterinarian
         type: string
     type: object
+  domain.SuccessResponse:
+    properties:
+      code:
+        example: 200
+        type: integer
+      message:
+        example: Operation was successful
+        type: string
+    type: object
   domain.TokensPair:
     properties:
       access_token:
         type: string
       refresh_token:
         type: string
-    type: object
-  handlers.LoginReq:
-    description: User login request payload
-    properties:
-      email:
-        description: |-
-          Email address of the user.
-          required: true
-          format: email
-          example: user@example.com
-        example: user@example.com
-        type: string
-      password:
-        description: |-
-          Password for the user account.
-          required: true
-          example: MySecretPassword123!
-        example: MySecretPassword123!
-        type: string
-    required:
-    - email
-    - password
     type: object
   handlers.RefreshReq:
     properties:
@@ -275,6 +311,47 @@ paths:
       summary: OAuth2.0 Provider Callback
       tags:
       - OAuth
+  /specialist/change-password:
+    patch:
+      consumes:
+      - application/json
+      description: Allows an authenticated specialist to change their password. All
+        active sessions will be terminated upon successful password change.
+      parameters:
+      - description: Change password request
+        in: body
+        name: request
+        required: true
+        schema:
+          $ref: '#/definitions/domain.ChangePassReq'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: Password updated successfully
+          schema:
+            $ref: '#/definitions/domain.SuccessResponse'
+        "400":
+          description: Invalid request payload or validation failed
+          schema:
+            $ref: '#/definitions/domain.ErrorResponse'
+        "401":
+          description: Unauthorized or invalid old password
+          schema:
+            $ref: '#/definitions/domain.ErrorResponse'
+        "404":
+          description: Specialist account not found
+          schema:
+            $ref: '#/definitions/domain.ErrorResponse'
+        "500":
+          description: Internal server error
+          schema:
+            $ref: '#/definitions/domain.ErrorResponse'
+      security:
+      - BearerAuth: []
+      summary: Change specialist password
+      tags:
+      - Specialist
   /specialist/login:
     post:
       consumes:
@@ -286,7 +363,7 @@ paths:
         name: request
         required: true
         schema:
-          $ref: '#/definitions/handlers.LoginReq'
+          $ref: '#/definitions/domain.LoginReq'
       produces:
       - application/json
       responses:
@@ -412,8 +489,8 @@ paths:
       tags:
       - Token
 schemes:
-- http
 - https
+- http
 securityDefinitions:
   BearerAuth:
     description: Type "Bearer" followed by a space and JWT token.

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -343,6 +343,10 @@ paths:
           description: Specialist account not found
           schema:
             $ref: '#/definitions/domain.ErrorResponse'
+        "409":
+          description: 'Conflict: New password is the same as the old one'
+          schema:
+            $ref: '#/definitions/domain.ErrorResponse'
         "500":
           description: Internal server error
           schema:

--- a/internal/app/specialist_mod.go
+++ b/internal/app/specialist_mod.go
@@ -72,6 +72,7 @@ var SpecialistModule = fx.Module("specialist",
 
 			protected := specRouterGroup.Use(mp.AuthMiddleware)
 			protected.GET("/me", handler.Me)
+			protected.PATCH("/change-password", handler.ChangePassword)
 
 			mp.Logger.Info("Registered specialist routes",
 				zap.String("base_path", SpecialistRoutePath),

--- a/internal/core/domain/errors.go
+++ b/internal/core/domain/errors.go
@@ -28,6 +28,7 @@ var (
 	ErrUnauthorized              = errors.New("unauthorized")
 	ErrForbidden                 = errors.New("forbidden")
 	ErrSessionTerminated         = errors.New("session terminated")
+	ErrPasswordReuse             = errors.New("password reuse")
 )
 
 // FieldError contains validation error details for a specific field.

--- a/internal/core/domain/requests.go
+++ b/internal/core/domain/requests.go
@@ -31,7 +31,7 @@ type ChangePassReq struct {
 	// maxLength: 255
 	// pattern: "^(?=.*[a-z])(?=.*[A-Z])(?=.*\\d)(?=.*[@$!%*?&])[A-Za-z\\d@$!%*?&]{12,255}$"
 	// example: NewStr0ngP@ssw0rd!
-	NewPass string `json:"new_password" binding:"required,min=12" validate:"required,min=12" example:"NewStr0ngP@ssw0rd!"`
+	NewPass string `json:"new_password" binding:"required" validate:"required,min=12,necsfield=CurrentPass" example:"NewStr0ngP@ssw0rd!"`
 }
 
 // SuccessResponse is a generic success response structure.

--- a/internal/core/domain/requests.go
+++ b/internal/core/domain/requests.go
@@ -1,0 +1,41 @@
+package domain
+
+// LoginReq represents the request body for user login.
+// @Description User login request payload
+type LoginReq struct {
+	// Email address of the user.
+	// required: true
+	// format: email
+	// example: user@example.com
+	Email string `json:"email" binding:"required,email" example:"user@example.com"`
+
+	// Password for the user account.
+	// required: true
+	// example: MySecretPassword123!
+	Password string `json:"password" binding:"required" example:"MySecretPassword123!"`
+}
+
+// ChangePassReq represents the request body for changing a specialist's password.
+// @Description Change password request payload
+type ChangePassReq struct {
+	// The specialist's current password.
+	// required: true
+	// example: MySecretPassword123!
+	CurrentPass string `json:"current_password" binding:"required" validate:"required" example:"MySecretPassword123!"`
+
+	// The new password for the specialist account.
+	// Must be at least 12 characters long.
+	// Must contain at least one uppercase letter, one lowercase letter, one number, and one special character from @$!%*?&.
+	// required: true
+	// minLength: 12
+	// maxLength: 255
+	// pattern: "^(?=.*[a-z])(?=.*[A-Z])(?=.*\\d)(?=.*[@$!%*?&])[A-Za-z\\d@$!%*?&]{12,255}$"
+	// example: NewStr0ngP@ssw0rd!
+	NewPass string `json:"new_password" binding:"required,min=12" validate:"required,min=12" example:"NewStr0ngP@ssw0rd!"`
+}
+
+// SuccessResponse is a generic success response structure.
+type SuccessResponse struct {
+	Code    int    `json:"code" example:"200"`
+	Message string `json:"message" example:"Operation was successful"`
+}

--- a/internal/core/ports/specialist_interface.go
+++ b/internal/core/ports/specialist_interface.go
@@ -26,6 +26,6 @@ type SpecialistRepository interface {
 	Save(ctx context.Context, name, email, phone, hash string) (int64, error)
 	GetByEmail(ctx context.Context, email string) (domain.Specialist, error)
 	GetByID(ctx context.Context, id int64) (domain.Specialist, error)
-	CheckCellValueExists(ctx context.Context, fieldName string, fieldValue string) (bool, error)
+	CheckFieldValueExists(ctx context.Context, fieldName string, fieldValue string) (bool, error)
 	UpdatePasswordHash(ctx context.Context, id int64, newHash string) error
 }

--- a/internal/core/ports/specialist_interface.go
+++ b/internal/core/ports/specialist_interface.go
@@ -11,6 +11,7 @@ type SpecialistHandlers interface {
 	Registration(c *gin.Context)
 	Login(c *gin.Context)
 	Me(c *gin.Context)
+	ChangePassword(c *gin.Context)
 }
 
 type SpecialistService interface {
@@ -18,18 +19,13 @@ type SpecialistService interface {
 	Login(ctx context.Context, email string, password string) (domain.SpecialistProfileDTO, error)
 	ShowByID(ctx context.Context, id int64) (domain.SpecialistProfileDTO, error)
 	ShowByEmail(ctx context.Context, email string) (domain.SpecialistProfileDTO, error)
-	// List(filter dto.ListFilter) ([]domain.User, error)
-	// Update(user domain.User) error
-	// Delete(id uint) error
+	ChangePassword(ctx context.Context, id int64, oldPass, newPass string) error
 }
 
 type SpecialistRepository interface {
 	Save(ctx context.Context, name, email, phone, hash string) (int64, error)
 	GetByEmail(ctx context.Context, email string) (domain.Specialist, error)
 	GetByID(ctx context.Context, id int64) (domain.Specialist, error)
-	CheckFieldValueExists(ctx context.Context, fieldName string, fieldValue string) (bool, error)
-	// Find(id uint) (domain.User, error)
-	// List(filter dto.ListFilter) ([]domain.User, error)
-	// Update(user domain.User) error
-	// Delete(id uint) error
+	CheckCellValueExists(ctx context.Context, fieldName string, fieldValue string) (bool, error)
+	UpdatePasswordHash(ctx context.Context, id int64, newHash string) error
 }

--- a/internal/core/ports/token_interface.go
+++ b/internal/core/ports/token_interface.go
@@ -6,7 +6,6 @@ import (
 	"time"
 
 	"github.com/gin-gonic/gin"
-	"github.com/markbates/goth"
 )
 
 type TokenHandlers interface {
@@ -16,9 +15,8 @@ type TokenHandlers interface {
 type TokenService interface {
 	GenerateTokenPair(ctx context.Context, sp *domain.SpecialistProfileDTO) (*domain.TokensPair, error)
 	ValidateToken(ctx context.Context, token string, isAccess bool) (jti string, userID string, err error)
-	RevokeToken(ctx context.Context, token string) error
-
-	// ExtractIDFromToken(requestToken string, entitysecret string) (string, error)
+	RevokeRefreshToken(ctx context.Context, token string) error
+	RevokeAllUserSessions(ctx context.Context, userID string) error
 }
 
 type TokenRepository interface {
@@ -26,5 +24,4 @@ type TokenRepository interface {
 	IsRefreshTokenValid(ctx context.Context, jti string, userID string) (bool, error)
 	RevokeRefreshToken(ctx context.Context, jti string, userID string) error
 	RevokeAllUserRefreshTokens(ctx context.Context, userID string) error
-	Set(ctx context.Context, user *goth.User) error
 }

--- a/internal/core/ports/validator_interface.go
+++ b/internal/core/ports/validator_interface.go
@@ -3,5 +3,6 @@ package ports
 import "pethelp-backend/internal/core/domain"
 
 type SpecialistValidator interface {
-	Validate(domain.RegistrationRequest) []domain.FieldError
+	ValidateRegistrationReq(domain.RegistrationRequest) []domain.FieldError
+	ValidateChangePasswordReq(domain.ChangePassReq) []domain.FieldError
 }

--- a/internal/core/services/specialist_service.go
+++ b/internal/core/services/specialist_service.go
@@ -44,7 +44,7 @@ func (ss *SpecialistServiceImpl) Registration(ctx context.Context, specialist do
 	timeoutCtx, cancel := context.WithTimeout(ctx, ss.defaultTimeout)
 	defer cancel()
 
-	exists, err := ss.specialistRepo.CheckCellValueExists(timeoutCtx, "email", specialist.Email)
+	exists, err := ss.specialistRepo.CheckFieldValueExists(timeoutCtx, "email", specialist.Email)
 	if err != nil {
 		ss.logger.Error("database check for existing email failed",
 			zap.String("email", specialist.Email),
@@ -184,6 +184,12 @@ func (ss *SpecialistServiceImpl) ChangePassword(ctx context.Context, id int64, C
 			zap.Error(err))
 		return domain.ErrInternalServer
 	}
+
+	// // Ensure new password is different from current password
+	// if specialist.PasswordHash == hashedPassword {
+	// 	ss.logger.Warn("password update failed: new password same as current", zap.Int64("id", id))
+	// 	return domain.ErrPasswordReuse
+	// }
 
 	if err := ss.specialistRepo.UpdatePasswordHash(timeoutCtx, id, hashedPassword); err != nil {
 		ss.logger.Error("failed to update password hash in database",

--- a/internal/core/services/specialist_service.go
+++ b/internal/core/services/specialist_service.go
@@ -44,7 +44,7 @@ func (ss *SpecialistServiceImpl) Registration(ctx context.Context, specialist do
 	timeoutCtx, cancel := context.WithTimeout(ctx, ss.defaultTimeout)
 	defer cancel()
 
-	exists, err := ss.specialistRepo.CheckFieldValueExists(timeoutCtx, "email", specialist.Email)
+	exists, err := ss.specialistRepo.CheckCellValueExists(timeoutCtx, "email", specialist.Email)
 	if err != nil {
 		ss.logger.Error("database check for existing email failed",
 			zap.String("email", specialist.Email),
@@ -156,4 +156,44 @@ func (ss *SpecialistServiceImpl) ShowByEmail(ctx context.Context, email string) 
 	specialistDTO = utils.ToSpecialistProfileDTO(specialistModel)
 
 	return specialistDTO, nil
+}
+
+func (ss *SpecialistServiceImpl) ChangePassword(ctx context.Context, id int64, CurrentPass, newPass string) error {
+	timeoutCtx, cancel := context.WithTimeout(ctx, ss.defaultTimeout)
+	defer cancel()
+
+	specialist, err := ss.specialistRepo.GetByID(timeoutCtx, id)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			ss.logger.Warn("attempt to update password for non-existent user", zap.Int64("id", id))
+			return domain.ErrAccountNotFound
+		}
+		ss.logger.Error("failed to get specialist by id during password update", zap.Int64("id", id), zap.Error(err))
+		return domain.ErrInternalServer
+	}
+
+	if err := utils.HashCompare(specialist.PasswordHash, CurrentPass); err != nil {
+		ss.logger.Warn("password update failed due to invalid old password", zap.Int64("id", id))
+		return domain.ErrInvalidCredentials
+	}
+
+	hashedPassword, err := utils.HashGen(newPass)
+	if err != nil {
+		ss.logger.Error("failed to generate password hash during password update",
+			zap.Int64("id", id),
+			zap.Error(err))
+		return domain.ErrInternalServer
+	}
+
+	if err := ss.specialistRepo.UpdatePasswordHash(timeoutCtx, id, hashedPassword); err != nil {
+		ss.logger.Error("failed to update password hash in database",
+			zap.Int64("id", id),
+			zap.Error(err))
+		if errors.Is(err, sql.ErrNoRows) {
+			return domain.ErrAccountNotFound
+		}
+		return domain.ErrInternalServer
+	}
+
+	return nil
 }

--- a/internal/core/services/tokens_service.go
+++ b/internal/core/services/tokens_service.go
@@ -150,7 +150,7 @@ func (ts *TokenServiceImpl) ValidateToken(ctx context.Context, token string, isA
 
 }
 
-func (ts *TokenServiceImpl) RevokeToken(ctx context.Context, token string) error {
+func (ts *TokenServiceImpl) RevokeRefreshToken(ctx context.Context, token string) error {
 	genClaims, err := genJWT.ParseRefreshToken(token, ts.jwtSecret)
 	if err != nil {
 		ts.logger.Error("failed to parse refresh token for revocation",
@@ -161,12 +161,25 @@ func (ts *TokenServiceImpl) RevokeToken(ctx context.Context, token string) error
 
 	err = ts.tokenRepo.RevokeRefreshToken(ctx, genClaims.ID, genClaims.UserID)
 	if err != nil {
-		ts.logger.Error("failed to revoke refresh token in repository",
+		ts.logger.Error("failed to revoke refresh token",
 			zap.String("jti", genClaims.ID),
 			zap.String("userID", genClaims.UserID),
 			zap.Error(err))
 		return domain.ErrInternalServer
 	}
+
+	return nil
+}
+
+func (ts *TokenServiceImpl) RevokeAllUserSessions(ctx context.Context, userID string) error {
+	if err := ts.tokenRepo.RevokeAllUserRefreshTokens(ctx, userID); err != nil {
+		ts.logger.Error("failed to revoke all user sessions",
+			zap.String("userID", userID),
+			zap.Error(err))
+		return domain.ErrInternalServer
+	}
+
+	ts.logger.Info("all sessions revoked for user", zap.String("userID", userID))
 
 	return nil
 }

--- a/internal/core/services/validator_service.go
+++ b/internal/core/services/validator_service.go
@@ -75,7 +75,7 @@ func (sv *SpecialistValidatorImpl) ValidateRegistrationReq(data domain.Registrat
 		}
 	}
 
-	passwordErrors := validatePasswordComplexity(data.Password)
+	passwordErrors := validatePasswordComplexity(data.Password, "Password")
 	if len(passwordErrors) > 0 {
 		validationErrors = append(validationErrors, passwordErrors...)
 	}
@@ -102,10 +102,12 @@ func (sv *SpecialistValidatorImpl) ValidateChangePasswordReq(reqData domain.Chan
 			fe.Field = err.Field()
 			switch err.Field() {
 			case "NewPass":
+				if err.Tag() == "necsfield" {
+					fe.Message = "The new password must be different from the current password (case-sensitive)."
+					break
+				}
 				fe.Message = err.Error()
-			case "NewPassRepeat":
-				fe.Message = err.Error()
-			case "OldPass":
+			case "CurrentPass":
 				fe.Message = "The current password is required."
 			}
 
@@ -113,7 +115,7 @@ func (sv *SpecialistValidatorImpl) ValidateChangePasswordReq(reqData domain.Chan
 		}
 	}
 
-	passwordErrors := validatePasswordComplexity(reqData.NewPass)
+	passwordErrors := validatePasswordComplexity(reqData.NewPass, "NewPass")
 	if len(passwordErrors) > 0 {
 		validationErrors = append(validationErrors, passwordErrors...)
 	}
@@ -125,7 +127,7 @@ func (sv *SpecialistValidatorImpl) ValidateChangePasswordReq(reqData domain.Chan
 	return nil
 }
 
-func validatePasswordComplexity(password string) []domain.FieldError {
+func validatePasswordComplexity(password, fieldName string) []domain.FieldError {
 
 	var (
 		hasUpper   bool
@@ -150,16 +152,16 @@ func validatePasswordComplexity(password string) []domain.FieldError {
 	}
 
 	if !hasUpper {
-		errors = append(errors, domain.FieldError{Field: "Password", Message: domain.ErrNoUppercase.Error()})
+		errors = append(errors, domain.FieldError{Field: fieldName, Message: domain.ErrNoUppercase.Error()})
 	}
 	if !hasLower {
-		errors = append(errors, domain.FieldError{Field: "Password", Message: domain.ErrNoLowercase.Error()})
+		errors = append(errors, domain.FieldError{Field: fieldName, Message: domain.ErrNoLowercase.Error()})
 	}
 	if !hasNumber {
-		errors = append(errors, domain.FieldError{Field: "Password", Message: domain.ErrNoNumber.Error()})
+		errors = append(errors, domain.FieldError{Field: fieldName, Message: domain.ErrNoNumber.Error()})
 	}
 	if !hasSpecial {
-		errors = append(errors, domain.FieldError{Field: "Password", Message: domain.ErrNoSpecialChar.Error()})
+		errors = append(errors, domain.FieldError{Field: fieldName, Message: domain.ErrNoSpecialChar.Error()})
 	}
 
 	return errors

--- a/internal/core/services/validator_service.go
+++ b/internal/core/services/validator_service.go
@@ -47,7 +47,7 @@ func NewCustomValidator() *SpecialistValidatorImpl {
 	return &SpecialistValidatorImpl{validator: v}
 }
 
-func (sv *SpecialistValidatorImpl) Validate(data domain.RegistrationRequest) []domain.FieldError {
+func (sv *SpecialistValidatorImpl) ValidateRegistrationReq(data domain.RegistrationRequest) []domain.FieldError {
 	var validationErrors []domain.FieldError
 
 	if err := sv.validator.Struct(data); err != nil {
@@ -76,6 +76,44 @@ func (sv *SpecialistValidatorImpl) Validate(data domain.RegistrationRequest) []d
 	}
 
 	passwordErrors := validatePasswordComplexity(data.Password)
+	if len(passwordErrors) > 0 {
+		validationErrors = append(validationErrors, passwordErrors...)
+	}
+
+	if len(validationErrors) > 0 {
+		return validationErrors
+	}
+
+	return nil
+}
+
+// ValidateChangePassword checks the change password request.
+func (sv *SpecialistValidatorImpl) ValidateChangePasswordReq(reqData domain.ChangePassReq) []domain.FieldError {
+	var validationErrors []domain.FieldError
+
+	if err := sv.validator.Struct(reqData); err != nil {
+		if _, ok := err.(*validator.InvalidValidationError); ok {
+			validationErrors = append(validationErrors, domain.FieldError{Field: "general", Message: "Invalid validation object"})
+			return validationErrors
+		}
+
+		for _, err := range err.(validator.ValidationErrors) {
+			var fe domain.FieldError
+			fe.Field = err.Field()
+			switch err.Field() {
+			case "NewPass":
+				fe.Message = err.Error()
+			case "NewPassRepeat":
+				fe.Message = err.Error()
+			case "OldPass":
+				fe.Message = "The current password is required."
+			}
+
+			validationErrors = append(validationErrors, fe)
+		}
+	}
+
+	passwordErrors := validatePasswordComplexity(reqData.NewPass)
 	if len(passwordErrors) > 0 {
 		validationErrors = append(validationErrors, passwordErrors...)
 	}

--- a/internal/handlers/jwt_handler.go
+++ b/internal/handlers/jwt_handler.go
@@ -123,7 +123,7 @@ func (th *TokenHandlerImpl) RefreshToken(c *gin.Context) {
 		return
 	}
 
-	if err := th.tokenService.RevokeToken(c.Request.Context(), dto.RefreshToken); err != nil {
+	if err := th.tokenService.RevokeRefreshToken(c.Request.Context(), dto.RefreshToken); err != nil {
 		th.logger.Error("failed to revoke used refresh token after issuing a new pair",
 			zap.Int64("userID", userID),
 			zap.Error(err),

--- a/internal/handlers/specialist_handler.go
+++ b/internal/handlers/specialist_handler.go
@@ -141,7 +141,7 @@ func (sh *SpecialistHandlerImpl) Login(c *gin.Context) {
 		var jsonErr *json.UnmarshalTypeError
 		var syntaxErr *json.SyntaxError
 
-		bindErr := fmt.Errorf("%s invalid registration payload: %w", operationSpHandler, err)
+		bindErr := fmt.Errorf("%s invalid login request payload: %w", operationSpHandler, err)
 
 		if errors.As(err, &jsonErr) {
 			message = "The request contains invalid data types."
@@ -268,6 +268,7 @@ func (sh *SpecialistHandlerImpl) Me(c *gin.Context) {
 // @Failure      400  {object}  domain.ErrorResponse "Invalid request payload or validation failed"
 // @Failure      401  {object}  domain.ErrorResponse "Unauthorized or invalid old password"
 // @Failure      404  {object}  domain.ErrorResponse "Specialist account not found"
+// @Failure      409  {object}  domain.ErrorResponse "Conflict: New password is the same as the old one"
 // @Failure      500  {object}  domain.ErrorResponse "Internal server error"
 // @Router       /specialist/change-password [patch]
 // @Security 	 BearerAuth
@@ -309,7 +310,7 @@ func (sh *SpecialistHandlerImpl) ChangePassword(c *gin.Context) {
 		var jsonErr *json.UnmarshalTypeError
 		var syntaxErr *json.SyntaxError
 
-		bindErr := fmt.Errorf("%s invalid registration payload: %w", operationSpHandler, err)
+		bindErr := fmt.Errorf("%s invalid change password request payload: %w", operationSpHandler, err)
 
 		if errors.As(err, &jsonErr) {
 			message = "The request contains invalid data types."
@@ -350,6 +351,10 @@ func (sh *SpecialistHandlerImpl) ChangePassword(c *gin.Context) {
 		}
 		if errors.Is(err, domain.ErrAccountNotFound) {
 			c.JSON(http.StatusNotFound, domain.ErrorResponse{Code: http.StatusNotFound, Message: "Specialist account not found"})
+			return
+		}
+		if errors.Is(err, domain.ErrPasswordReuse) {
+			c.JSON(http.StatusConflict, domain.ErrorResponse{Code: http.StatusConflict, Message: "New password cannot be the same as the old password."})
 			return
 		}
 

--- a/internal/handlers/specialist_handler.go
+++ b/internal/handlers/specialist_handler.go
@@ -85,8 +85,8 @@ func (sh *SpecialistHandlerImpl) Registration(c *gin.Context) {
 		})
 		return
 	}
-	// — Run field‐validator on it
-	if validationErrors := sh.validator.Validate(req); len(validationErrors) > 0 {
+
+	if validationErrors := sh.validator.ValidateRegistrationReq(req); len(validationErrors) > 0 {
 		sh.logger.Error("validation failed", zap.Any("errors", validationErrors))
 		c.JSON(http.StatusBadRequest, domain.ErrorResponse{
 			Code:    http.StatusBadRequest,
@@ -96,7 +96,6 @@ func (sh *SpecialistHandlerImpl) Registration(c *gin.Context) {
 		return
 	}
 
-	//email uniqueness
 	id, err := sh.specialistService.Registration(c.Request.Context(), req)
 	if err != nil {
 		if errors.Is(err, domain.ErrAccountAlreadyExists) {
@@ -122,32 +121,17 @@ func (sh *SpecialistHandlerImpl) Registration(c *gin.Context) {
 
 }
 
-// LoginReq represents the request body for user login.
-// @Description User login request payload
-type LoginReq struct {
-	// Email address of the user.
-	// required: true
-	// format: email
-	// example: user@example.com
-	Email string `json:"email" binding:"required,email" example:"user@example.com"`
-
-	// Password for the user account.
-	// required: true
-	// example: MySecretPassword123!
-	Password string `json:"password" binding:"required" example:"MySecretPassword123!"`
-}
-
 // @Summary Login
 // @Description Login specialist
 // @Tags Specialist
 // @Accept       json
 // @Produce      json
-// @Param request body LoginReq true "Login request body"
+// @Param request body domain.LoginReq true "Login request body"
 // @Success 200 {object} domain.TokensPair "Login succeeded"
 // @Failure      400,401,500 {object} domain.ErrorResponse
 // @Router /specialist/login [post]
 func (sh *SpecialistHandlerImpl) Login(c *gin.Context) {
-	var loginData LoginReq
+	var loginData domain.LoginReq
 
 	//bind and validate JSON payload
 	if err := c.ShouldBindJSON(&loginData); err != nil {
@@ -271,4 +255,120 @@ func (sh *SpecialistHandlerImpl) Me(c *gin.Context) {
 	}
 
 	c.JSON(http.StatusOK, specialist)
+}
+
+// ChangePassword
+// @Summary      Change specialist password
+// @Description  Allows an authenticated specialist to change their password. All active sessions will be terminated upon successful password change.
+// @Tags         Specialist
+// @Accept       json
+// @Produce      json
+// @Param        request body domain.ChangePassReq true "Change password request"
+// @Success      200  {object}  domain.SuccessResponse "Password updated successfully"
+// @Failure      400  {object}  domain.ErrorResponse "Invalid request payload or validation failed"
+// @Failure      401  {object}  domain.ErrorResponse "Unauthorized or invalid old password"
+// @Failure      404  {object}  domain.ErrorResponse "Specialist account not found"
+// @Failure      500  {object}  domain.ErrorResponse "Internal server error"
+// @Router       /specialist/change-password [patch]
+// @Security 	 BearerAuth
+func (sh *SpecialistHandlerImpl) ChangePassword(c *gin.Context) {
+	userIDRaw, exists := c.Get("userID")
+	if !exists {
+		sh.logger.Warn("userID not found in context, middleware might not have run or failed")
+		c.JSON(http.StatusUnauthorized, domain.ErrorResponse{
+			Code:    http.StatusUnauthorized,
+			Message: "Unauthorized",
+		})
+		return
+	}
+
+	userIDStr, ok := userIDRaw.(string)
+	if !ok {
+		sh.logger.Error("userID in context is not a string", zap.Any("type", fmt.Sprintf("%T", userIDRaw)))
+		c.JSON(http.StatusInternalServerError, domain.ErrorResponse{
+			Code:    http.StatusInternalServerError,
+			Message: "Internal server error",
+		})
+		return
+	}
+
+	userID, err := strconv.ParseInt(userIDStr, 10, 64)
+	if err != nil {
+		sh.logger.Error("failed to parse userID from context", zap.String("userID", userIDStr), zap.Error(err))
+		c.JSON(http.StatusInternalServerError, domain.ErrorResponse{Code: http.StatusInternalServerError, Message: "Internal server error"})
+		return
+	}
+
+	var reqData domain.ChangePassReq
+
+	//bind and validate JSON payload
+	if err := c.ShouldBindJSON(&reqData); err != nil {
+		var fieldErrors []domain.FieldError
+		message := "Invalid request payload"
+
+		var jsonErr *json.UnmarshalTypeError
+		var syntaxErr *json.SyntaxError
+
+		bindErr := fmt.Errorf("%s invalid registration payload: %w", operationSpHandler, err)
+
+		if errors.As(err, &jsonErr) {
+			message = "The request contains invalid data types."
+			fieldErrors = append(fieldErrors, domain.FieldError{
+				Field:   jsonErr.Field,
+				Message: fmt.Sprintf("Expected type '%s' for field.", jsonErr.Type),
+			})
+		} else if errors.As(err, &syntaxErr) {
+			message = "The request body is not valid JSON."
+		} else if err == io.EOF {
+			message = "Request body cannot be empty."
+		}
+
+		sh.logger.Error("bindJSON failed", zap.Error(bindErr), zap.Any("details", fieldErrors))
+		c.JSON(http.StatusBadRequest, domain.ErrorResponse{
+			Code:    http.StatusBadRequest,
+			Message: message,
+			Details: fieldErrors,
+		})
+		return
+	}
+
+	if validationErrors := sh.validator.ValidateChangePasswordReq(reqData); len(validationErrors) > 0 {
+		sh.logger.Error("validation failed", zap.Any("errors", validationErrors))
+		c.JSON(http.StatusBadRequest, domain.ErrorResponse{
+			Code:    http.StatusBadRequest,
+			Message: "validation failed",
+			Details: validationErrors,
+		})
+		return
+	}
+
+	err = sh.specialistService.ChangePassword(c.Request.Context(), userID, reqData.CurrentPass, reqData.NewPass)
+	if err != nil {
+		if errors.Is(err, domain.ErrInvalidCredentials) {
+			c.JSON(http.StatusUnauthorized, domain.ErrorResponse{Code: http.StatusUnauthorized, Message: "Invalid old password"})
+			return
+		}
+		if errors.Is(err, domain.ErrAccountNotFound) {
+			c.JSON(http.StatusNotFound, domain.ErrorResponse{Code: http.StatusNotFound, Message: "Specialist account not found"})
+			return
+		}
+
+		sh.logger.Error("failed to update password", zap.Int64("userID", userID), zap.Error(err))
+		c.JSON(http.StatusInternalServerError, domain.ErrorResponse{Code: http.StatusInternalServerError, Message: "Internal server error"})
+		return
+	}
+
+	err = sh.tokenService.RevokeAllUserSessions(c.Request.Context(), userIDStr)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, domain.ErrorResponse{
+			Code:    http.StatusInternalServerError,
+			Message: "Internal server error"})
+		return
+	}
+
+	c.JSON(http.StatusOK, domain.SuccessResponse{
+		Code:    http.StatusOK,
+		Message: "Password changed successfully.",
+	})
+
 }

--- a/internal/repositories/specialist_repo.go
+++ b/internal/repositories/specialist_repo.go
@@ -16,7 +16,7 @@ import (
 )
 
 const (
-	curentTableName     = "specialists"
+	currentTableName    = "specialists"
 	operationSpecialist = "specialist_repo: "
 )
 
@@ -41,7 +41,7 @@ func (sr *SpecialistRepositoryImpl) Save(ctx context.Context, name, email, phone
 	}
 	saveTime := time.Now().In(loc)
 
-	query, args, err := sq.Insert(curentTableName).
+	query, args, err := sq.Insert(currentTableName).
 		Columns(
 			"name",
 			"email",
@@ -98,7 +98,7 @@ func (sr *SpecialistRepositoryImpl) GetByEmail(ctx context.Context, email string
 
 	var item domain.Specialist
 	query, args, err := sq.Select("*").
-		From(curentTableName).
+		From(currentTableName).
 		Where(sq.Eq{"email": email}).
 		PlaceholderFormat(sq.Dollar). // conn, err := sr.database.Connection()
 		ToSql()
@@ -144,7 +144,7 @@ func (sr *SpecialistRepositoryImpl) GetByID(ctx context.Context, id int64) (doma
 
 	var item domain.Specialist
 	query, args, err := sq.Select("*").
-		From(curentTableName).
+		From(currentTableName).
 		Where(sq.Eq{"id": id}).
 		PlaceholderFormat(sq.Dollar).
 		ToSql()
@@ -186,13 +186,13 @@ func (sr *SpecialistRepositoryImpl) GetByID(ctx context.Context, id int64) (doma
 	return item, nil
 }
 
-func (sr *SpecialistRepositoryImpl) CheckCellValueExists(ctx context.Context, fieldName string, fieldValue string) (bool, error) {
+func (sr *SpecialistRepositoryImpl) CheckFieldValueExists(ctx context.Context, fieldName string, fieldValue string) (bool, error) {
 	if fieldName == "" || fieldValue == "" {
 		return false, fmt.Errorf("%s field name or field value cannot be empty", operationSpecialist)
 	}
 
 	innerSQL, innerArgs, err := sq.Select("1").
-		From(curentTableName).
+		From(currentTableName).
 		Where(sq.Eq{fieldName: fieldValue}).
 		PlaceholderFormat(sq.Dollar).ToSql()
 	if err != nil {
@@ -233,9 +233,16 @@ func (sr *SpecialistRepositoryImpl) CheckCellValueExists(ctx context.Context, fi
 
 func (sr *SpecialistRepositoryImpl) UpdatePasswordHash(ctx context.Context, id int64, newHash string) error {
 
-	query, args, err := sq.Update(curentTableName).
+	loc, err := time.LoadLocation("Europe/London")
+	if err != nil {
+		locErr := fmt.Errorf("%s failed to time load location: %w", operationSpecialist, err)
+		return locErr
+	}
+	updateTime := time.Now().In(loc)
+
+	query, args, err := sq.Update(currentTableName).
 		Set("password_hash", newHash).
-		Set("updated_at", time.Now()).
+		Set("updated_at", updateTime).
 		Where(sq.Eq{"id": id}).
 		PlaceholderFormat(sq.Dollar).
 		ToSql()
@@ -267,5 +274,8 @@ func (sr *SpecialistRepositoryImpl) UpdatePasswordHash(ctx context.Context, id i
 		return sql.ErrNoRows
 	}
 
-	return tx.Commit(ctx)
+	if err := tx.Commit(ctx); err != nil {
+		return fmt.Errorf("%s failed to commit sql transaction: %w", operationSpecialist, err)
+	}
+	return nil
 }

--- a/internal/repositories/specialist_repo.go
+++ b/internal/repositories/specialist_repo.go
@@ -186,7 +186,7 @@ func (sr *SpecialistRepositoryImpl) GetByID(ctx context.Context, id int64) (doma
 	return item, nil
 }
 
-func (sr *SpecialistRepositoryImpl) CheckFieldValueExists(ctx context.Context, fieldName string, fieldValue string) (bool, error) {
+func (sr *SpecialistRepositoryImpl) CheckCellValueExists(ctx context.Context, fieldName string, fieldValue string) (bool, error) {
 	if fieldName == "" || fieldValue == "" {
 		return false, fmt.Errorf("%s field name or field value cannot be empty", operationSpecialist)
 	}
@@ -229,4 +229,43 @@ func (sr *SpecialistRepositoryImpl) CheckFieldValueExists(ctx context.Context, f
 	}
 
 	return exists, nil
+}
+
+func (sr *SpecialistRepositoryImpl) UpdatePasswordHash(ctx context.Context, id int64, newHash string) error {
+
+	query, args, err := sq.Update(curentTableName).
+		Set("password_hash", newHash).
+		Set("updated_at", time.Now()).
+		Where(sq.Eq{"id": id}).
+		PlaceholderFormat(sq.Dollar).
+		ToSql()
+	if err != nil {
+		return fmt.Errorf("%s failed to build update query: %w", operationSpecialist, err)
+	}
+
+	conn, err := sr.DBPool.Pool().Acquire(ctx)
+	if err != nil {
+		return fmt.Errorf("%s failed to take DB pool connection: %w", operationSpecialist, err)
+	}
+	defer conn.Release()
+
+	tx, err := conn.BeginTx(ctx, pgx.TxOptions{
+		IsoLevel:   pgx.ReadCommitted,
+		AccessMode: pgx.ReadWrite,
+	})
+	if err != nil {
+		return fmt.Errorf("%s failed to begin sql transaction: %w", operationSpecialist, err)
+	}
+	defer tx.Rollback(ctx)
+
+	result, err := tx.Exec(ctx, query, args...)
+	if err != nil {
+		return fmt.Errorf("%s failed to execute update query: %w", operationSpecialist, err)
+	}
+
+	if result.RowsAffected() == 0 {
+		return sql.ErrNoRows
+	}
+
+	return tx.Commit(ctx)
 }

--- a/internal/repositories/token_repo.go
+++ b/internal/repositories/token_repo.go
@@ -2,15 +2,12 @@ package repositories
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"strconv"
 	"time"
 
 	"pethelp-backend/internal/core/domain"
 	redisDB "pethelp-backend/pkg/database/redis"
-
-	"github.com/markbates/goth"
 )
 
 const (
@@ -129,24 +126,6 @@ func (r *TokenRepoImpl) RevokeAllUserRefreshTokens(ctx context.Context, userID s
 	_, err = pipe.Exec(ctx)
 	if err != nil {
 		return fmt.Errorf("%s failed to revoke all user tokens: %w", operationToken, err)
-	}
-	return nil
-}
-
-const userKeyPrefix = "email:"
-const operationName = "oauth_repo"
-
-func (r *TokenRepoImpl) Set(ctx context.Context, user *goth.User) error {
-
-	userJSON, err := json.Marshal(user)
-	if err != nil {
-		return fmt.Errorf("%s failed to marshal user data: %w", operationName, err)
-	}
-
-	key := fmt.Sprintf("%s%s", userKeyPrefix, user.Email) // Use a unique identifier like user.ID
-	err = r.redis.Client().Set(ctx, key, userJSON, 0).Err()
-	if err != nil {
-		return fmt.Errorf("%s failed to save user to Redis: %w", operationName, err)
 	}
 	return nil
 }


### PR DESCRIPTION
feat(change-password): Implement specialist password change with session revocation

This commit introduces the functionality for an authenticated specialist to change their password.

A new endpoint `PATCH /specialist/change-password` is added, which requires the specialist's current password and a new password. The request is validated to ensure password strength and that the new password is not the same as the old one.

As a critical security enhancement, upon a successful password change, all of the user's active sessions are immediately revoked. This is achieved by invalidating all of their refresh tokens stored in Redis, ensuring that any potentially compromised sessions are terminated and the user must log in again on all devices.

This implementation includes:
- A new `ChangePassword` handler and corresponding service and repository methods.
- A `RevokeAllUserSessions` method in the token service and repository to manage session invalidation.
- Updated Swagger documentation for the new endpoint.

Resolves: PT-62


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a PATCH endpoint for specialists to securely change their password, terminating all active sessions upon success.
  * Introduced detailed password complexity validation with clear error messages for password change requests.
  * Updated login request schema to improve validation and consistency.

* **Improvements**
  * Enhanced validation and error handling for login and password change processes.
  * Improved session management by enabling revocation of all user sessions after password changes.
  * Reordered supported protocols to prioritize HTTPS over HTTP.

* **Documentation**
  * Updated Swagger API documentation to include the new password change endpoint, updated schemas, and authentication details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->