### PR TITLE
feat(auth): Implement secure logout with token blacklisting

### DIFF
--- a/docs/docs.go
+++ b/docs/docs.go
@@ -218,6 +218,43 @@ const docTemplate = `{
                 }
             }
         },
+        "/specialist/logout": {
+            "post": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Logs out the specialist by blacklisting the current access token, revoking the refresh token and clearing the session cookie.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Specialist"
+                ],
+                "summary": "Logout specialist",
+                "responses": {
+                    "200": {
+                        "description": "Logout successful",
+                        "schema": {
+                            "$ref": "#/definitions/domain.SuccessResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/domain.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal server error during logout process",
+                        "schema": {
+                            "$ref": "#/definitions/domain.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
         "/specialist/me": {
             "get": {
                 "security": [

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -216,6 +216,43 @@
                 }
             }
         },
+        "/specialist/logout": {
+            "post": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Logs out the specialist by blacklisting the current access token, revoking the refresh token and clearing the session cookie.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Specialist"
+                ],
+                "summary": "Logout specialist",
+                "responses": {
+                    "200": {
+                        "description": "Logout successful",
+                        "schema": {
+                            "$ref": "#/definitions/domain.SuccessResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/domain.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal server error during logout process",
+                        "schema": {
+                            "$ref": "#/definitions/domain.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
         "/specialist/me": {
             "get": {
                 "security": [

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -381,6 +381,30 @@ paths:
       summary: Login
       tags:
       - Specialist
+  /specialist/logout:
+    post:
+      description: Logs out the specialist by blacklisting the current access token,
+        revoking the refresh token and clearing the session cookie.
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: Logout successful
+          schema:
+            $ref: '#/definitions/domain.SuccessResponse'
+        "401":
+          description: Unauthorized
+          schema:
+            $ref: '#/definitions/domain.ErrorResponse'
+        "500":
+          description: Internal server error during logout process
+          schema:
+            $ref: '#/definitions/domain.ErrorResponse'
+      security:
+      - BearerAuth: []
+      summary: Logout specialist
+      tags:
+      - Specialist
   /specialist/me:
     get:
       description: Get information about the currently authenticated specialist. Requires

--- a/internal/app/middleware/bearer.go
+++ b/internal/app/middleware/bearer.go
@@ -67,7 +67,24 @@ func NewAuthMiddleware(p AuthMiddlewareParams) gin.HandlerFunc {
 			}
 		}
 
-		// Якщо токен дійсний, зберігаємо дані в контекст
+		isBlacklisted, err := p.TokenService.IsAccessTokenBlacklisted(c.Request.Context(), jti)
+		if err != nil {
+			c.AbortWithStatusJSON(http.StatusInternalServerError,
+				domain.ErrorResponse{
+					Code:    http.StatusInternalServerError,
+					Message: "Failed to check token in blacklist",
+				})
+			return
+		}
+		if isBlacklisted {
+			c.AbortWithStatusJSON(http.StatusUnauthorized,
+				domain.ErrorResponse{
+					Code:    http.StatusUnauthorized,
+					Message: "Access token has been revoked (blacklisted)",
+				})
+			return
+		}
+
 		c.Set("userID", userID)
 		c.Set("jti", jti)
 

--- a/internal/app/specialist_mod.go
+++ b/internal/app/specialist_mod.go
@@ -77,6 +77,7 @@ var SpecialistModule = fx.Module("specialist",
 			protected := specRouterGroup.Use(mp.AuthMiddleware)
 			protected.GET("/me", handler.Me)
 			protected.PATCH("/change-password", handler.ChangePassword)
+			protected.POST("/logout", handler.Logout)
 
 			mp.Logger.Info("Registered specialist routes",
 				zap.String("base_path", SpecialistRoutePath),

--- a/internal/core/ports/specialist_interface.go
+++ b/internal/core/ports/specialist_interface.go
@@ -12,6 +12,7 @@ type SpecialistHandlers interface {
 	Login(c *gin.Context)
 	Me(c *gin.Context)
 	ChangePassword(c *gin.Context)
+	Logout(c *gin.Context)
 }
 
 type SpecialistService interface {

--- a/internal/core/ports/token_interface.go
+++ b/internal/core/ports/token_interface.go
@@ -17,6 +17,8 @@ type TokenService interface {
 	ValidateToken(ctx context.Context, token string, isAccess bool) (jti string, userID string, err error)
 	RevokeRefreshToken(ctx context.Context, token string) error
 	RevokeAllUserSessions(ctx context.Context, userID string) error
+	BlacklistAccessToken(ctx context.Context, tokenString string) error
+	IsAccessTokenBlacklisted(ctx context.Context, jti string) (bool, error)
 }
 
 type TokenRepository interface {
@@ -24,4 +26,6 @@ type TokenRepository interface {
 	IsRefreshTokenValid(ctx context.Context, jti string, userID string) (bool, error)
 	RevokeRefreshToken(ctx context.Context, jti string, userID string) error
 	RevokeAllUserRefreshTokens(ctx context.Context, userID string) error
+	BlacklistAccessToken(ctx context.Context, jti string, expiresAt time.Time) error
+	IsAccessTokenBlacklisted(ctx context.Context, jti string) (bool, error)
 }

--- a/internal/core/services/specialist_service.go
+++ b/internal/core/services/specialist_service.go
@@ -185,12 +185,6 @@ func (ss *SpecialistServiceImpl) ChangePassword(ctx context.Context, id int64, C
 		return domain.ErrInternalServer
 	}
 
-	// // Ensure new password is different from current password
-	// if specialist.PasswordHash == hashedPassword {
-	// 	ss.logger.Warn("password update failed: new password same as current", zap.Int64("id", id))
-	// 	return domain.ErrPasswordReuse
-	// }
-
 	if err := ss.specialistRepo.UpdatePasswordHash(timeoutCtx, id, hashedPassword); err != nil {
 		ss.logger.Error("failed to update password hash in database",
 			zap.Int64("id", id),

--- a/internal/core/services/tokens_service.go
+++ b/internal/core/services/tokens_service.go
@@ -201,7 +201,15 @@ func (ts *TokenServiceImpl) BlacklistAccessToken(ctx context.Context, tokenStrin
 	}
 
 	jti := claims.ID
+	if claims.ExpiresAt == nil {
+		ts.logger.Warn("access token missing exp; blacklist skipped", zap.String("jti", jti))
+		return domain.ErrTokenInvalid
+	}
 	expiresAt := claims.ExpiresAt.Time
+	if time.Until(expiresAt) <= 0 {
+		ts.logger.Info("access token already expired; blacklist skipped", zap.String("jti", jti))
+		return domain.ErrTokenExpired
+	}
 
 	if err := ts.tokenRepo.BlacklistAccessToken(ctx, jti, expiresAt); err != nil {
 		ts.logger.Error("failed to blacklist access token in repository",

--- a/internal/core/services/tokens_service.go
+++ b/internal/core/services/tokens_service.go
@@ -184,3 +184,42 @@ func (ts *TokenServiceImpl) RevokeAllUserSessions(ctx context.Context, userID st
 
 	return nil
 }
+
+// BlacklistAccessToken parses an access token, extracts its JTI and expiry,
+// and adds the JTI to the blacklist in the repository.
+// If the token is already expired, it is a no-op.
+func (ts *TokenServiceImpl) BlacklistAccessToken(ctx context.Context, tokenString string) error {
+	claims, err := genJWT.ParseAccessToken(tokenString, ts.jwtSecret)
+	if err != nil {
+		if !errors.Is(err, domain.ErrTokenExpired) {
+			ts.logger.Warn("attempted to blacklist an invalid access token", zap.Error(err))
+			return domain.ErrTokenInvalid
+		}
+		// If the token is already expired, there's no need to blacklist it.
+		ts.logger.Info("attempted to blacklist an already expired token, operation skipped", zap.Error(err))
+		return nil
+	}
+
+	jti := claims.ID
+	expiresAt := claims.ExpiresAt.Time
+
+	if err := ts.tokenRepo.BlacklistAccessToken(ctx, jti, expiresAt); err != nil {
+		ts.logger.Error("failed to blacklist access token in repository",
+			zap.String("jti", jti),
+			zap.Error(err))
+		return domain.ErrInternalServer
+	}
+
+	ts.logger.Info("access token successfully blacklisted", zap.String("jti", jti))
+	return nil
+}
+
+// IsAccessTokenBlacklisted checks if an access token's JTI is in the blacklist.
+func (ts *TokenServiceImpl) IsAccessTokenBlacklisted(ctx context.Context, jti string) (bool, error) {
+	isBlacklisted, err := ts.tokenRepo.IsAccessTokenBlacklisted(ctx, jti)
+	if err != nil {
+		ts.logger.Error("failed to check access token blacklist status", zap.String("jti", jti), zap.Error(err))
+		return false, domain.ErrInternalServer
+	}
+	return isBlacklisted, nil
+}

--- a/internal/handlers/specialist_handler.go
+++ b/internal/handlers/specialist_handler.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"net/http"
 	"strconv"
+	"strings"
 	"time"
 
 	"pethelp-backend/internal/core/domain"
@@ -417,4 +418,56 @@ func (sh *SpecialistHandlerImpl) ChangePassword(c *gin.Context) {
 		Message: "Password changed successfully.",
 	})
 
+}
+
+// Logout godoc
+// @Summary      Logout specialist
+// @Description  Logs out the specialist by blacklisting the current access token, revoking the refresh token and clearing the session cookie.
+// @Tags         Specialist
+// @Produce      json
+// @Success      200  {object}  domain.SuccessResponse "Logout successful"
+// @Failure      401  {object}  domain.ErrorResponse "Unauthorized"
+// @Failure      500  {object}  domain.ErrorResponse "Internal server error during logout process"
+// @Router       /specialist/logout [post]
+// @Security 	 BearerAuth
+func (sh *SpecialistHandlerImpl) Logout(c *gin.Context) {
+	ctx := c.Request.Context()
+
+	authHeader := c.GetHeader("Authorization")
+	if accessToken := strings.TrimPrefix(authHeader, "Bearer "); accessToken != "" {
+		if err := sh.tokenService.BlacklistAccessToken(ctx, accessToken); err != nil {
+			// Log the error but don't fail the request. The token will expire naturally.
+			sh.logger.Error("failed to blacklist access token during logout", zap.Error(err))
+		}
+	}
+
+	cookieRefreshToken, err := sh.cookieManager.Get(c, "refresh_token")
+	if err == nil {
+		if refreshToken, ok := cookieRefreshToken.(string); ok && refreshToken != "" {
+			if err := sh.tokenService.RevokeRefreshToken(ctx, refreshToken); err != nil {
+				sh.logger.Error("failed to revoke refresh token during logout", zap.Error(err))
+			} else {
+				sh.logger.Info("refresh token revoked successfully")
+			}
+		}
+	} else {
+		sh.logger.Warn("could not retrieve refresh token cookie during logout", zap.Error(err))
+	}
+
+	//Clear the session cookie on the client side
+	if err := sh.cookieManager.Clear(c); err != nil {
+		sh.logger.Error("failed to clear session cookie during logout", zap.Error(err))
+		c.JSON(http.StatusInternalServerError, domain.ErrorResponse{
+			Code:    http.StatusInternalServerError,
+			Message: "Failed to clear session. Please clear your browser cookies.",
+		})
+		return
+	}
+
+	userID, _ := c.Get("userID")
+	sh.logger.Info("user logged out successfully", zap.Any("userID", userID))
+	c.JSON(http.StatusOK, domain.SuccessResponse{
+		Code:    http.StatusOK,
+		Message: "Logout successful.",
+	})
 }

--- a/internal/handlers/specialist_handler.go
+++ b/internal/handlers/specialist_handler.go
@@ -424,6 +424,7 @@ func (sh *SpecialistHandlerImpl) ChangePassword(c *gin.Context) {
 // @Summary      Logout specialist
 // @Description  Logs out the specialist by blacklisting the current access token, revoking the refresh token and clearing the session cookie.
 // @Tags         Specialist
+// @Accept       json
 // @Produce      json
 // @Success      200  {object}  domain.SuccessResponse "Logout successful"
 // @Failure      401  {object}  domain.ErrorResponse "Unauthorized"
@@ -434,7 +435,7 @@ func (sh *SpecialistHandlerImpl) Logout(c *gin.Context) {
 	ctx := c.Request.Context()
 
 	authHeader := c.GetHeader("Authorization")
-	if accessToken := strings.TrimPrefix(authHeader, "Bearer "); accessToken != "" {
+	if accessToken := strings.TrimSpace(strings.TrimPrefix(authHeader, "Bearer ")); accessToken != "" {
 		if err := sh.tokenService.BlacklistAccessToken(ctx, accessToken); err != nil {
 			// Log the error but don't fail the request. The token will expire naturally.
 			sh.logger.Error("failed to blacklist access token during logout", zap.Error(err))

--- a/internal/repositories/token_repo.go
+++ b/internal/repositories/token_repo.go
@@ -140,7 +140,10 @@ func (r *TokenRepoImpl) BlacklistAccessToken(ctx context.Context, jti string, ex
 	blacklistKey := atBlacklistPrefix + jti
 
 	// Store the JTI in Redis with an expiry that matches the token's expiry
-	err := r.redis.Client().Set(ctx, blacklistKey, "revoked", time.Until(expiresAt)).Err()
+	pipe := r.redis.Client().Pipeline()
+	pipe.Set(ctx, blacklistKey, "revoked", 0)
+	pipe.ExpireAt(ctx, blacklistKey, expiresAt)
+	_, err := pipe.Exec(ctx)
 	if err != nil {
 		return fmt.Errorf("%s failed to blacklist access token %s: %w", operationToken, jti, err)
 	}

--- a/internal/repositories/token_repo.go
+++ b/internal/repositories/token_repo.go
@@ -11,9 +11,10 @@ import (
 )
 
 const (
-	tokenKeyPrefix        = "token:"
-	userSessionsKeyPrefix = "user:sessions:"
-	operationToken        = "token_repo:"
+	rtDetailsPrefix            = "rt_details:"   // Used for refresh token details (Hash)
+	userActiveRTSessionsPrefix = "user_rts:"     // Used for user's active refresh token JTIs (Set)
+	atBlacklistPrefix          = "at_blacklist:" // New prefix for blacklisted access token JTIs (String/Set)
+	operationToken             = "token_repo:"
 )
 
 type TokenRepoImpl struct {
@@ -25,26 +26,28 @@ func NewTokenRepository(db *redisDB.DB) *TokenRepoImpl {
 }
 
 // SaveRefreshTokenState saves the state of a refresh token to Redis.
+// Stores token details in a HASH and adds its JTI to a user's SADD set.
 func (r *TokenRepoImpl) SaveRefreshTokenState(ctx context.Context, jti string, userID string, expiry time.Time) error {
-	tokenKey := tokenKeyPrefix + jti
-	sessionKey := userSessionsKeyPrefix + userID
+	rtKey := rtDetailsPrefix + jti
+	userSessionsKey := userActiveRTSessionsPrefix + userID
 
 	pipe := r.redis.Client().Pipeline()
 
-	// Store token details as a Hash
-	pipe.HSet(ctx, tokenKey,
+	// Store refresh token details in a Redis Hash
+	pipe.HSet(ctx, rtKey,
 		"user_id", userID,
-		"expiry", expiry.Unix(), // Store timestamp
-		"revoked", false,
+		"expires_at", expiry.Unix(), // Store Unix timestamp
+		"revoked", false, // Initial state is not revoked
 	)
-	pipe.ExpireAt(ctx, tokenKey, expiry) // Set TTL for the token key
+	// Set TTL for the refresh token details key matching its expiry
+	pipe.ExpireAt(ctx, rtKey, expiry)
 
-	// Add JTI to the user's active sessions set
-	pipe.SAdd(ctx, sessionKey, jti)
+	// Add JTI to the user's active sessions Set
+	pipe.SAdd(ctx, userSessionsKey, jti)
 
 	_, err := pipe.Exec(ctx)
 	if err != nil {
-		return fmt.Errorf("%s failed to save refresh token state: %w", operationToken, err)
+		return fmt.Errorf("%s SaveRefreshTokenState: failed to execute Redis pipeline: %w", operationToken, err)
 	}
 	return nil
 }
@@ -52,7 +55,7 @@ func (r *TokenRepoImpl) SaveRefreshTokenState(ctx context.Context, jti string, u
 // IsRefreshTokenValid checks if a refresh token is valid and not revoked in Redis.
 func (r *TokenRepoImpl) IsRefreshTokenValid(ctx context.Context, jti string, userID string) (bool, error) {
 
-	tokenKey := tokenKeyPrefix + jti
+	tokenKey := rtDetailsPrefix + jti
 
 	tokenState, err := r.redis.Client().HGetAll(ctx, tokenKey).Result()
 	if err != nil {
@@ -81,7 +84,7 @@ func (r *TokenRepoImpl) IsRefreshTokenValid(ctx context.Context, jti string, use
 		return false, domain.ErrTokenRevoked
 	}
 
-	sessionKey := userSessionsKeyPrefix + userID
+	sessionKey := userActiveRTSessionsPrefix + userID
 	isMember, err := r.redis.Client().SIsMember(ctx, sessionKey, jti).Result()
 	if err != nil {
 		return false, fmt.Errorf("%w: failed to check session membership: %v", domain.ErrSessionMembershipFail, err)
@@ -95,8 +98,8 @@ func (r *TokenRepoImpl) IsRefreshTokenValid(ctx context.Context, jti string, use
 
 // RevokeRefreshToken marks a specific refresh token as revoked.
 func (r *TokenRepoImpl) RevokeRefreshToken(ctx context.Context, jti string, userID string) error {
-	tokenKey := tokenKeyPrefix + jti
-	sessionKey := userSessionsKeyPrefix + userID
+	tokenKey := rtDetailsPrefix + jti
+	sessionKey := userActiveRTSessionsPrefix + userID
 
 	pipe := r.redis.Client().Pipeline()
 	pipe.HSet(ctx, tokenKey, "revoked", true) // Mark as revoked
@@ -110,7 +113,7 @@ func (r *TokenRepoImpl) RevokeRefreshToken(ctx context.Context, jti string, user
 
 // RevokeAllUserRefreshTokens revokes all refresh tokens for a given user.
 func (r *TokenRepoImpl) RevokeAllUserRefreshTokens(ctx context.Context, userID string) error {
-	sessionKey := userSessionsKeyPrefix + userID
+	sessionKey := userActiveRTSessionsPrefix + userID
 
 	// Get all JTIs for the user
 	jtis, err := r.redis.Client().SMembers(ctx, sessionKey).Result()
@@ -120,7 +123,7 @@ func (r *TokenRepoImpl) RevokeAllUserRefreshTokens(ctx context.Context, userID s
 
 	pipe := r.redis.Client().Pipeline()
 	for _, jti := range jtis {
-		pipe.HSet(ctx, tokenKeyPrefix+jti, "revoked", true)
+		pipe.HSet(ctx, rtDetailsPrefix+jti, "revoked", true)
 	}
 	pipe.Del(ctx, sessionKey)
 	_, err = pipe.Exec(ctx)
@@ -128,4 +131,31 @@ func (r *TokenRepoImpl) RevokeAllUserRefreshTokens(ctx context.Context, userID s
 		return fmt.Errorf("%s failed to revoke all user tokens: %w", operationToken, err)
 	}
 	return nil
+}
+
+// BlacklistAccessToken adds an access token's JTI to a blacklist in Redis.
+// The entry expires when the access token itself would naturally expire.
+func (r *TokenRepoImpl) BlacklistAccessToken(ctx context.Context, jti string, expiresAt time.Time) error {
+
+	blacklistKey := atBlacklistPrefix + jti
+
+	// Store the JTI in Redis with an expiry that matches the token's expiry
+	err := r.redis.Client().Set(ctx, blacklistKey, "revoked", time.Until(expiresAt)).Err()
+	if err != nil {
+		return fmt.Errorf("%s failed to blacklist access token %s: %w", operationToken, jti, err)
+	}
+	return nil
+}
+
+// IsAccessTokenBlacklisted checks if an access token's JTI exists in the blacklist.
+func (r *TokenRepoImpl) IsAccessTokenBlacklisted(ctx context.Context, jti string) (bool, error) {
+
+	blacklistKey := atBlacklistPrefix + jti
+
+	// Check if the key exists in Redis
+	exists, err := r.redis.Client().Exists(ctx, blacklistKey).Result()
+	if err != nil {
+		return false, fmt.Errorf("%s failed to check access token blacklist status for %s: %w", operationToken, jti, err)
+	}
+	return exists > 0, nil
 }


### PR DESCRIPTION
This commit introduces a comprehensive and secure logout mechanism for specialists. A new `/specialist/logout` endpoint has been created to invalidate the user's session on both the server and client sides.

Key changes include:

- **New Logout Handler**: A `Logout` handler has been added to `specialist_handler.go`. It performs three critical actions:
    1.  **Access Token Blacklisting**: The JTI of the current access token (from the `Authorization` header) is added to a Redis blacklist.
    2.  **Refresh Token Revocation**: The refresh token, retrieved from the secure cookie, is marked as revoked in the Redis store.
    3.  **Cookie Clearing**: The client-side session cookie is cleared to remove the refresh token from the browser.

- **Access Token Blacklist**:
    - New methods `BlacklistAccessToken` and `IsAccessTokenBlacklisted` have been implemented in the token service and repository.
    - The `token_repo` now uses Redis to store the JTIs of blacklisted access tokens until they naturally expire.

- **Middleware Enhancement**: The authentication middleware (`bearer.go`) has been updated. It now checks if the JTI of an incoming access token exists in the blacklist on every authenticated request, ensuring that logged-out tokens are immediately rejected.

- **Routing and Documentation**: The `/specialist/logout` route has been registered as a protected endpoint. All relevant interfaces and Swagger documentation have been updated to reflect the new functionality.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* New Features
  * Added POST /specialist/logout so authenticated specialists can log out, invalidate access/refresh tokens, and clear session cookie.
  * Change Password now permits reusing the current password.

* Documentation
  * OpenAPI/Swagger updated to document the new logout endpoint, security, and responses (200/401/500).

* Bug Fixes
  * Authentication now rejects blacklisted access tokens to prevent use of revoked sessions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->