### PR TITLE
PT-102-feat/specialist-account-delete

### DIFF
--- a/database/migrations/000053_mod_specialist_table_add_delete_initiated_at.up.sql
+++ b/database/migrations/000053_mod_specialist_table_add_delete_initiated_at.up.sql
@@ -1,0 +1,2 @@
+ALTER TABLE specialists
+ADD COLUMN delete_initiated_at TIMESTAMP WITH TIME ZONE DEFAULT NULL;

--- a/database/migrations/000053_mod_specialist_table_add_delete_initiated_at.up.sql.sql
+++ b/database/migrations/000053_mod_specialist_table_add_delete_initiated_at.up.sql.sql
@@ -1,2 +1,0 @@
-ALTER TABLE specialists
-ADD COLUMN delete_initiated_at TIMESTAMP WITH TIME ZONE DEFAULT NULL;

--- a/database/migrations/000053_mod_specialist_table_add_delete_initiated_at.up.sql.sql
+++ b/database/migrations/000053_mod_specialist_table_add_delete_initiated_at.up.sql.sql
@@ -1,0 +1,2 @@
+ALTER TABLE specialists
+ADD COLUMN delete_initiated_at TIMESTAMP WITH TIME ZONE DEFAULT NULL;

--- a/database/migrations/000054_mod_specialist_table_del_delete_initiated_at.down.sql
+++ b/database/migrations/000054_mod_specialist_table_del_delete_initiated_at.down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE specialists DROP COLUMN IF EXISTS delete_initiated_at;

--- a/docs/docs.go
+++ b/docs/docs.go
@@ -424,6 +424,47 @@ const docTemplate = `{
                         }
                     }
                 }
+            },
+            "delete": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Initiates account deletion. The account will be deactivated immediately and permanently deleted after 7 days if not restored.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Specialist"
+                ],
+                "summary": "Delete specialist account (Soft Delete)",
+                "responses": {
+                    "204": {
+                        "description": "Deletion initiated successfully",
+                        "schema": {
+                            "$ref": "#/definitions/domain.SuccessResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/domain.UnauthorizedError"
+                        }
+                    },
+                    "404": {
+                        "description": "Account not found",
+                        "schema": {
+                            "$ref": "#/definitions/domain.NotFoundError"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal server error",
+                        "schema": {
+                            "$ref": "#/definitions/domain.InternalServerError"
+                        }
+                    }
+                }
             }
         },
         "/specialist/me/status": {

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -422,6 +422,47 @@
                         }
                     }
                 }
+            },
+            "delete": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Initiates account deletion. The account will be deactivated immediately and permanently deleted after 7 days if not restored.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Specialist"
+                ],
+                "summary": "Delete specialist account (Soft Delete)",
+                "responses": {
+                    "204": {
+                        "description": "Deletion initiated successfully",
+                        "schema": {
+                            "$ref": "#/definitions/domain.SuccessResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/domain.UnauthorizedError"
+                        }
+                    },
+                    "404": {
+                        "description": "Account not found",
+                        "schema": {
+                            "$ref": "#/definitions/domain.NotFoundError"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal server error",
+                        "schema": {
+                            "$ref": "#/definitions/domain.InternalServerError"
+                        }
+                    }
+                }
             }
         },
         "/specialist/me/status": {

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -753,6 +753,33 @@ paths:
       tags:
       - Specialist
   /specialist/me:
+    delete:
+      description: Initiates account deletion. The account will be deactivated immediately
+        and permanently deleted after 7 days if not restored.
+      produces:
+      - application/json
+      responses:
+        "204":
+          description: Deletion initiated successfully
+          schema:
+            $ref: '#/definitions/domain.SuccessResponse'
+        "401":
+          description: Unauthorized
+          schema:
+            $ref: '#/definitions/domain.UnauthorizedError'
+        "404":
+          description: Account not found
+          schema:
+            $ref: '#/definitions/domain.NotFoundError'
+        "500":
+          description: Internal server error
+          schema:
+            $ref: '#/definitions/domain.InternalServerError'
+      security:
+      - BearerAuth: []
+      summary: Delete specialist account (Soft Delete)
+      tags:
+      - Specialist
     get:
       description: Get information about the currently authenticated specialist. Requires
         a valid Bearer token.

--- a/go.mod
+++ b/go.mod
@@ -20,6 +20,7 @@ require (
 	github.com/nyaruka/phonenumbers v1.6.6
 	github.com/oklog/ulid/v2 v2.1.1
 	github.com/redis/go-redis/v9 v9.16.0
+	github.com/robfig/cron/v3 v3.0.1
 	github.com/swaggo/files v1.0.1
 	github.com/swaggo/gin-swagger v1.6.1
 	github.com/swaggo/swag v1.16.6

--- a/go.sum
+++ b/go.sum
@@ -188,6 +188,8 @@ github.com/quic-go/quic-go v0.54.0 h1:6s1YB9QotYI6Ospeiguknbp2Znb/jZYjZLRXn9kMQB
 github.com/quic-go/quic-go v0.54.0/go.mod h1:e68ZEaCdyviluZmy44P6Iey98v/Wfz6HCjQEm+l8zTY=
 github.com/redis/go-redis/v9 v9.16.0 h1:OotgqgLSRCmzfqChbQyG1PHC3tLNR89DG4jdOERSEP4=
 github.com/redis/go-redis/v9 v9.16.0/go.mod h1:u410H11HMLoB+TP67dz8rL9s6QW2j76l0//kSOd3370=
+github.com/robfig/cron/v3 v3.0.1 h1:WdRxkvbJztn8LMz/QEvLN5sBU+xKpSqwwUO1Pjr4qDs=
+github.com/robfig/cron/v3 v3.0.1/go.mod h1:eQICP3HwyT7UooqI/z+Ov+PtYAWygg1TEWWzGIFLtro=
 github.com/rogpeppe/go-internal v1.14.1 h1:UQB4HGPB6osV0SQTLymcB4TgvyWu6ZyliaW0tI/otEQ=
 github.com/rogpeppe/go-internal v1.14.1/go.mod h1:MaRKkUm5W0goXpeCfT7UZI6fk/L7L7so1lCWt35ZSgc=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -71,6 +71,7 @@ func NewApp() fx.Option {
 		TokenModule,
 		FileUploadModule,
 		UnauthAppointmentModule,
+		CronModule,
 
 		fx.StartTimeout(10*time.Second),
 	)

--- a/internal/app/cron_mod.go
+++ b/internal/app/cron_mod.go
@@ -1,0 +1,67 @@
+package app
+
+import (
+	"context"
+	"time"
+
+	"pethelp-backend/internal/core/ports"
+
+	"github.com/robfig/cron/v3"
+	"go.uber.org/fx"
+	"go.uber.org/zap"
+)
+
+// CronModule defines the module for background tasks.
+var CronModule = fx.Module("cron",
+	fx.Invoke(RegisterCronJobs),
+)
+
+// RegisterCronJobs initializes the cron scheduler and registers the daily cleanup job.
+func RegisterCronJobs(
+	lc fx.Lifecycle,
+	logger *zap.Logger,
+	specialistService ports.SpecialistService,
+) {
+	// Create a new cron scheduler
+	scheduler := cron.New()
+
+	// Register the job to run at 02:00 AM every day.
+	// Cron expression: "0 2 * * *" (Minute 0, Hour 2, Every Day, Every Month, Every Day of Week)
+	_, err := scheduler.AddFunc("0 2 * * *", func() {
+		logger.Info("starting scheduled daily cleanup of expired accounts")
+
+		ctx := context.Background()
+
+		// Execute the cleanup logic
+		if err := specialistService.DeleteExpiredAccounts(ctx); err != nil {
+			logger.Error("scheduled daily cleanup failed", zap.Error(err))
+		} else {
+			logger.Info("scheduled daily cleanup completed successfully")
+		}
+	})
+
+	if err != nil {
+		logger.Fatal("failed to add cron job", zap.Error(err))
+	}
+
+	// Hook into the application lifecycle
+	lc.Append(fx.Hook{
+		OnStart: func(ctx context.Context) error {
+			logger.Info("starting cron scheduler")
+			scheduler.Start() // Start the scheduler in its own goroutine
+			return nil
+		},
+		OnStop: func(ctx context.Context) error {
+			logger.Info("stopping cron scheduler")
+			jobCtx := scheduler.Stop() // Stop the scheduler gracefully
+
+			select {
+			case <-jobCtx.Done():
+				return nil
+			case <-time.After(5 * time.Second):
+				logger.Warn("cron scheduler stop timed out")
+				return nil
+			}
+		},
+	})
+}

--- a/internal/app/specialist_mod.go
+++ b/internal/app/specialist_mod.go
@@ -64,7 +64,8 @@ var SpecialistModule = fx.Module("specialist",
 		),
 
 		fx.Annotate(services.NewCookieManager,
-			fx.As(new(ports.CookieManager))),
+			fx.As(new(ports.CookieManager)),
+		),
 
 		middleware.NewAuthMiddleware,
 	),
@@ -84,6 +85,7 @@ var SpecialistModule = fx.Module("specialist",
 			protected.PATCH("/me/status", handler.DeactivateProfile)
 			protected.POST("/portfolio", mp.FileHandler.UploadPortfolio)
 			protected.DELETE("/portfolio/image", mp.FileHandler.DeletePortfolioImage)
+			protected.DELETE("/me", handler.DeleteAccount)
 
 			mp.Logger.Info("Registered specialist routes",
 				zap.String("base_path", SpecialistRoutePath),

--- a/internal/core/domain/requests.go
+++ b/internal/core/domain/requests.go
@@ -40,3 +40,10 @@ type SuccessResponse struct {
 	Message string `json:"message" example:"Operation was successful"`
 	Data    any    `json:"data,omitempty"`
 }
+
+// SuccessDelete is a success delete profile response structure.
+type SuccessDelete struct {
+	Code    int    `json:"code" example:"204"`
+	Message string `json:"message" example:"Operation was successful"`
+	Data    any    `json:"data,omitempty"`
+}

--- a/internal/core/domain/specialist.go
+++ b/internal/core/domain/specialist.go
@@ -9,27 +9,28 @@ import (
 
 // Specialist represents the 'specialists' table in the database.
 type Specialist struct {
-	ID             int64          `json:"id" db:"id"`
-	Name           sql.NullString `json:"name" db:"name"`
-	FamilyName     sql.NullString `json:"family_name" db:"family_name"`
-	Phone          sql.NullString `json:"phone" db:"phone"`
-	Email          string         `json:"email" db:"email"`
-	PasswordHash   string         `json:"-" db:"password_hash"`
-	Bio            sql.NullString `json:"bio" db:"bio"`
-	Avatar         sql.NullString `json:"avatar" db:"avatar"`
-	AddressID      sql.NullInt32  `json:"address_id" db:"address_id"`
-	OrganisationID sql.NullInt32  `json:"organisation_id" db:"organisation_id"`
-	BranchID       sql.NullInt32  `json:"branch_id" db:"branch_id"`
-	Position       sql.NullString `json:"position" db:"position"`
-	Experience     sql.NullInt32  `json:"experience" db:"experience"`
-	Description    sql.NullString `json:"description" db:"description"`
-	ImageID        []pgtype.Text  `json:"image_id" db:"image_id"`
-	IsBanned       bool           `json:"is_banned" db:"is_banned"`
-	IsDeleted      bool           `json:"is_deleted" db:"is_deleted"`
-	IsActive       bool           `json:"is_active" db:"is_active"`
-	IsVerified     bool           `json:"is_verified" db:"is_verified"`
-	CreatedAt      time.Time      `json:"created_at" db:"created_at"`
-	UpdatedAt      time.Time      `json:"updated_at" db:"updated_at"`
+	ID                int64          `json:"id" db:"id"`
+	Name              sql.NullString `json:"name" db:"name"`
+	FamilyName        sql.NullString `json:"family_name" db:"family_name"`
+	Phone             sql.NullString `json:"phone" db:"phone"`
+	Email             string         `json:"email" db:"email"`
+	PasswordHash      string         `json:"-" db:"password_hash"`
+	Bio               sql.NullString `json:"bio" db:"bio"`
+	Avatar            sql.NullString `json:"avatar" db:"avatar"`
+	AddressID         sql.NullInt32  `json:"address_id" db:"address_id"`
+	OrganisationID    sql.NullInt32  `json:"organisation_id" db:"organisation_id"`
+	BranchID          sql.NullInt32  `json:"branch_id" db:"branch_id"`
+	Position          sql.NullString `json:"position" db:"position"`
+	Experience        sql.NullInt32  `json:"experience" db:"experience"`
+	Description       sql.NullString `json:"description" db:"description"`
+	ImageID           []pgtype.Text  `json:"image_id" db:"image_id"`
+	IsBanned          bool           `json:"is_banned" db:"is_banned"`
+	IsDeleted         bool           `json:"is_deleted" db:"is_deleted"`
+	DeleteInitiatedAt sql.NullTime   `json:"delete_initiated_at" db:"delete_initiated_at"`
+	IsActive          bool           `json:"is_active" db:"is_active"`
+	IsVerified        bool           `json:"is_verified" db:"is_verified"`
+	CreatedAt         time.Time      `json:"created_at" db:"created_at"`
+	UpdatedAt         time.Time      `json:"updated_at" db:"updated_at"`
 }
 
 // SpecialistProfDTO represents the public profile data of a specialist.

--- a/internal/core/ports/specialist_interface.go
+++ b/internal/core/ports/specialist_interface.go
@@ -3,6 +3,7 @@ package ports
 import (
 	"context"
 	"pethelp-backend/internal/core/domain"
+	"time"
 
 	"github.com/gin-gonic/gin"
 )
@@ -15,6 +16,7 @@ type SpecialistHandlers interface {
 	Logout(c *gin.Context)
 	UpdateProfile(c *gin.Context)
 	DeactivateProfile(c *gin.Context)
+	DeleteAccount(c *gin.Context)
 }
 
 type SpecialistService interface {
@@ -29,6 +31,8 @@ type SpecialistService interface {
 	DeactivateProfile(ctx context.Context, specialistID int64, isActive bool) error
 	AddImages(ctx context.Context, specialistID int64, imageURLs []string) error
 	DeleteImage(ctx context.Context, specialistID int64, imageURL string) error
+	InitiateSoftDelete(ctx context.Context, id int64) error
+	DeleteExpiredAccounts(ctx context.Context) error
 }
 
 type SpecialistRepository interface {
@@ -43,4 +47,11 @@ type SpecialistRepository interface {
 	UpdateIsActive(ctx context.Context, id int64, isActive bool) error
 	AddImages(ctx context.Context, specialistID int64, imageURLs []string) error
 	DeleteImage(ctx context.Context, specialistID int64, imageURL string) error
+	MarkAsDeleted(ctx context.Context, id int64) error
+	// GetExpiredAccounts returns a list of accounts whose deletion grace period has expired.
+	GetExpiredAccounts(ctx context.Context, thresholdTime time.Time) ([]domain.Specialist, error)
+	// DeleteAllServices removes all service records for a specific specialist.
+	DeleteAllServices(ctx context.Context, specialistID int64) error
+	// HardDelete permanently deletes a specialist record by ID.
+	HardDelete(ctx context.Context, id int64) error
 }

--- a/internal/core/services/cookie_manager_service.go
+++ b/internal/core/services/cookie_manager_service.go
@@ -2,6 +2,7 @@ package services
 
 import (
 	"errors"
+	"fmt"
 	"net/http"
 	"pethelp-backend/internal/config"
 	"pethelp-backend/internal/core/ports"
@@ -63,7 +64,8 @@ func (cm *cookieManager) Middleware() gin.HandlerFunc {
 }
 
 // Set saves a key-value pair to the user's session.
-// It uses the session stored in the gin.Context by the middleware.
+// Note: This only stages the change. You must call `Save()` on the manager
+// to write the changes to the response cookie.
 func (cm *cookieManager) Set(c *gin.Context, key string, value interface{}) {
 	session := sessions.Default(c)
 	session.Set(key, value)
@@ -75,7 +77,7 @@ func (cm *cookieManager) Get(c *gin.Context, key string) (interface{}, error) {
 
 	value := session.Get(key)
 	if value == nil {
-		return nil, errors.New("session value not found for key: " + key)
+		return nil, fmt.Errorf("session value not found for key: %s", key)
 	}
 
 	return value, nil
@@ -109,6 +111,8 @@ func (cm *cookieManager) ResetOptions(c *gin.Context) {
 
 // NewSession sets multiple key-value pairs and saves the session.
 // This is useful for creating a new session with multiple values at once, for example, after a login.
+// Note: This only stages the changes. You must call `Save()` on the manager
+// to write the changes to the response cookie.
 func (cm *cookieManager) BulkSet(c *gin.Context, values map[string]interface{}) {
 	session := sessions.Default(c)
 	for key, value := range values {

--- a/internal/core/services/specialist_service.go
+++ b/internal/core/services/specialist_service.go
@@ -16,15 +16,17 @@ import (
 
 type SpecialistServiceImpl struct {
 	specialistRepo ports.SpecialistRepository
+	fileService    ports.FileUploadService
 	logger         *zap.Logger
 	defaultTimeout time.Duration
 }
 
 var _ ports.SpecialistService = (*SpecialistServiceImpl)(nil)
 
-func NewSpecialistService(repo ports.SpecialistRepository, logger *zap.Logger, cfg config.AuthConfig) *SpecialistServiceImpl {
+func NewSpecialistService(repo ports.SpecialistRepository, fileSrv ports.FileUploadService, logger *zap.Logger, cfg config.AuthConfig) *SpecialistServiceImpl {
 	return &SpecialistServiceImpl{
 		specialistRepo: repo,
+		fileService:    fileSrv,
 		logger:         logger,
 		defaultTimeout: cfg.DefaultTimeout,
 	}
@@ -328,4 +330,100 @@ func (ss *SpecialistServiceImpl) DeactivateProfile(ctx context.Context, id int64
 
 	return nil
 
+}
+
+// InitiateSoftDelete marks the specialist's account for deletion.
+// It first checks if the user exists, then sets the 'is_deleted' flag and schedules the deletion.
+func (ss *SpecialistServiceImpl) InitiateSoftDelete(ctx context.Context, id int64) error {
+	timeoutCtx, cancel := context.WithTimeout(ctx, ss.defaultTimeout)
+	defer cancel()
+
+	// Check if the user exists before attempting to delete
+	if _, err := ss.specialistRepo.GetByID(timeoutCtx, id); err != nil {
+		if errors.Is(err, sql.ErrNoRows) || errors.Is(err, domain.ErrAccountNotFound) {
+			ss.logger.Warn("attempt to soft delete non-existent user", zap.Int64("id", id))
+			return domain.ErrAccountNotFound
+		}
+		ss.logger.Error("failed to check specialist existence during soft delete",
+			zap.Int64("id", id),
+			zap.Error(err))
+		return domain.ErrInternalServer
+	}
+
+	// Proceed with marking the account as deleted
+	err := ss.specialistRepo.MarkAsDeleted(timeoutCtx, id)
+	if err != nil {
+		ss.logger.Error("failed to mark specialist as deleted in database",
+			zap.Int64("id", id),
+			zap.Error(err))
+		return domain.ErrInternalServer
+	}
+
+	return nil
+}
+
+// DeleteExpiredAccounts handles the comprehensive cleanup of expired profiles.
+func (ss *SpecialistServiceImpl) DeleteExpiredAccounts(ctx context.Context) error {
+	// Define timeout and threshold
+	timeoutCtx, cancel := context.WithTimeout(ctx, 10*time.Minute) // Increased timeout for S3 operations
+	defer cancel()
+
+	retentionPeriod := 7 * 24 * time.Hour
+
+	thresholdTime := time.Now().Add(-retentionPeriod)
+
+	// Fetch accounts to be deleted
+	expiredAccounts, err := ss.specialistRepo.GetExpiredAccounts(timeoutCtx, thresholdTime)
+	if err != nil {
+		ss.logger.Error("failed to fetch expired accounts", zap.Error(err))
+		return domain.ErrInternalServer
+	}
+
+	if len(expiredAccounts) == 0 {
+		ss.logger.Info("no expired accounts found for deletion")
+		return nil
+	}
+
+	ss.logger.Info("starting cleanup for expired accounts", zap.Int("count", len(expiredAccounts)))
+
+	// Iterate and clean up each account
+	for _, specialist := range expiredAccounts {
+		logger := ss.logger.With(zap.Int64("specialistID", specialist.ID))
+
+		// A. Delete Avatar from S3
+		if specialist.Avatar.Valid && specialist.Avatar.String != "" {
+			if err := ss.fileService.DeleteAvatar(timeoutCtx, specialist.Avatar.String); err != nil {
+				// Log error but continue deletion process
+				logger.Error("failed to delete avatar from S3",
+					zap.String("url", specialist.Avatar.String),
+					zap.Error(err))
+			}
+		}
+
+		// Delete Portfolio Images from S3
+		for _, img := range specialist.ImageID {
+			if img.Valid && img.String != "" {
+				if err := ss.fileService.DeletePortfolioImage(timeoutCtx, img.String); err != nil {
+					logger.Error("failed to delete portfolio image from S3",
+						zap.String("url", img.String),
+						zap.Error(err))
+				}
+			}
+		}
+
+		// Delete Associated Services from DB
+		if err := ss.specialistRepo.DeleteAllServices(timeoutCtx, specialist.ID); err != nil {
+			logger.Error("failed to delete associated services", zap.Error(err))
+		}
+
+		// Hard Delete the Specialist Record
+		if err := ss.specialistRepo.HardDelete(timeoutCtx, specialist.ID); err != nil {
+			logger.Error("failed to hard delete specialist record", zap.Error(err))
+			continue
+		}
+
+		logger.Info("successfully deleted expired specialist account and resources")
+	}
+
+	return nil
 }

--- a/internal/core/services/specialist_service.go
+++ b/internal/core/services/specialist_service.go
@@ -390,7 +390,18 @@ func (ss *SpecialistServiceImpl) DeleteExpiredAccounts(ctx context.Context) erro
 	for _, specialist := range expiredAccounts {
 		logger := ss.logger.With(zap.Int64("specialistID", specialist.ID))
 
-		// A. Delete Avatar from S3
+		// Delete Associated Services from DB
+		if err := ss.specialistRepo.DeleteAllServices(timeoutCtx, specialist.ID); err != nil {
+			logger.Error("failed to delete associated services", zap.Error(err))
+		}
+
+		// Hard Delete the Specialist Record
+		if err := ss.specialistRepo.HardDelete(timeoutCtx, specialist.ID); err != nil {
+			logger.Error("failed to hard delete specialist record", zap.Error(err))
+			continue
+		}
+
+		// Delete Avatar from S3
 		if specialist.Avatar.Valid && specialist.Avatar.String != "" {
 			if err := ss.fileService.DeleteAvatar(timeoutCtx, specialist.Avatar.String); err != nil {
 				// Log error but continue deletion process
@@ -409,17 +420,6 @@ func (ss *SpecialistServiceImpl) DeleteExpiredAccounts(ctx context.Context) erro
 						zap.Error(err))
 				}
 			}
-		}
-
-		// Delete Associated Services from DB
-		if err := ss.specialistRepo.DeleteAllServices(timeoutCtx, specialist.ID); err != nil {
-			logger.Error("failed to delete associated services", zap.Error(err))
-		}
-
-		// Hard Delete the Specialist Record
-		if err := ss.specialistRepo.HardDelete(timeoutCtx, specialist.ID); err != nil {
-			logger.Error("failed to hard delete specialist record", zap.Error(err))
-			continue
 		}
 
 		logger.Info("successfully deleted expired specialist account and resources")

--- a/internal/handlers/specialist_handler.go
+++ b/internal/handlers/specialist_handler.go
@@ -606,3 +606,58 @@ func (sh *SpecialistHandlerImpl) DeactivateProfile(c *gin.Context) {
 		Message: message,
 	})
 }
+
+// DeleteAccount
+// @Summary      Delete specialist account (Soft Delete)
+// @Description  Initiates account deletion. The account will be deactivated immediately and permanently deleted after 7 days if not restored.
+// @Tags         Specialist
+// @Produce      json
+// @Success      204  {object}  domain.SuccessResponse "Deletion initiated successfully"
+// @Failure      401  {object}  domain.UnauthorizedError "Unauthorized"
+// @Failure      404  {object}  domain.NotFoundError "Account not found"
+// @Failure      500  {object}  domain.InternalServerError "Internal server error"
+// @Router       /specialist/me [delete]
+// @Security 	 BearerAuth
+func (sh *SpecialistHandlerImpl) DeleteAccount(c *gin.Context) {
+	userID, ok := getUserIDFromContext(c, sh.logger)
+	if !ok {
+		return
+	}
+
+	// Initiate soft delete logic in the service layer
+	err := sh.specialistService.InitiateSoftDelete(c.Request.Context(), userID)
+	if err != nil {
+		if errors.Is(err, domain.ErrAccountNotFound) {
+			c.JSON(http.StatusNotFound, domain.NotFoundError{
+				Code:    http.StatusNotFound,
+				Message: "Specialist account not found",
+			})
+			return
+		}
+		sh.logger.Error("failed to initiate soft delete", zap.Int64("userID", userID), zap.Error(err))
+		c.JSON(http.StatusInternalServerError, domain.InternalServerError{
+			Code:    http.StatusInternalServerError,
+			Message: "Internal server error",
+		})
+		return
+	}
+
+	// Revoke all user sessions (invalidate refresh tokens) to force logout
+	if err := sh.tokenService.RevokeAllUserSessions(c.Request.Context(), strconv.FormatInt(userID, 10)); err != nil {
+		sh.logger.Error("failed to revoke user sessions after soft delete",
+			zap.Int64("userID", userID),
+			zap.Error(err))
+	}
+
+	// Clear session cookies on the client side
+	if err := sh.cookieManager.Clear(c); err != nil {
+		sh.logger.Error("failed to clear cookies after soft delete",
+			zap.Int64("userID", userID),
+			zap.Error(err))
+	}
+
+	c.JSON(http.StatusOK, domain.SuccessDelete{
+		Code:    http.StatusNoContent,
+		Message: "Account scheduled for deletion. It will be permanently removed in 7 days.",
+	})
+}

--- a/internal/handlers/specialist_handler.go
+++ b/internal/handlers/specialist_handler.go
@@ -612,7 +612,7 @@ func (sh *SpecialistHandlerImpl) DeactivateProfile(c *gin.Context) {
 // @Description  Initiates account deletion. The account will be deactivated immediately and permanently deleted after 7 days if not restored.
 // @Tags         Specialist
 // @Produce      json
-// @Success      204  {object}  domain.SuccessResponse "Deletion initiated successfully"
+// @Success      204  {object}  domain.SuccessDelete "Deletion initiated successfully"
 // @Failure      401  {object}  domain.UnauthorizedError "Unauthorized"
 // @Failure      404  {object}  domain.NotFoundError "Account not found"
 // @Failure      500  {object}  domain.InternalServerError "Internal server error"
@@ -641,6 +641,10 @@ func (sh *SpecialistHandlerImpl) DeleteAccount(c *gin.Context) {
 		})
 		return
 	}
+
+	sh.logger.Info("account deletion initiated",
+		zap.Int64("userID", userID),
+		zap.String("event", "soft_delete_initiated"))
 
 	// Revoke all user sessions (invalidate refresh tokens) to force logout
 	if err := sh.tokenService.RevokeAllUserSessions(c.Request.Context(), strconv.FormatInt(userID, 10)); err != nil {

--- a/internal/repositories/pgs_specialist_repo.go
+++ b/internal/repositories/pgs_specialist_repo.go
@@ -17,8 +17,9 @@ import (
 )
 
 const (
-	currentTableName    = "specialists"
-	operationSpecialist = "specialist_repo: "
+	currentTableName           = "specialists"
+	serviceSpecialistTableName = "specialist_services"
+	operationSpecialist        = "specialist_repo: "
 )
 
 type SpecialistRepositoryImpl struct {
@@ -529,5 +530,180 @@ func (sr *SpecialistRepositoryImpl) UpdateIsActive(ctx context.Context, id int64
 	if result.RowsAffected() == 0 {
 		return sql.ErrNoRows
 	}
+	return tx.Commit(ctx)
+}
+
+// MarkAsDeleted marks the specialist profile as deleted (Soft Delete) within a transaction.
+func (sr *SpecialistRepositoryImpl) MarkAsDeleted(ctx context.Context, id int64) error {
+	loc, err := time.LoadLocation("Europe/London")
+	if err != nil {
+		return fmt.Errorf("%s failed to load time location: %w", operationSpecialist, err)
+	}
+	updateTime := time.Now().In(loc)
+
+	// Build the update query
+	query, args, err := sq.Update(currentTableName).
+		Set("is_deleted", true).
+		Set("is_active", false). // Deactivate profile immediately
+		Set("delete_initiated_at", updateTime).
+		Set("updated_at", updateTime).
+		Where(sq.Eq{"id": id}).
+		PlaceholderFormat(sq.Dollar).
+		ToSql()
+
+	if err != nil {
+		return fmt.Errorf("%s failed to build mark as deleted query: %w", operationSpecialist, err)
+	}
+
+	// Acquire connection from the pool
+	conn, err := sr.DBPool.Pool().Acquire(ctx)
+	if err != nil {
+		return fmt.Errorf("%s failed to take DB pool connection: %w", operationSpecialist, err)
+	}
+	defer conn.Release()
+
+	// Begin transaction
+	tx, err := conn.BeginTx(ctx, pgx.TxOptions{
+		IsoLevel:   pgx.ReadCommitted,
+		AccessMode: pgx.ReadWrite,
+	})
+	if err != nil {
+		return fmt.Errorf("%s failed to begin sql transaction: %w", operationSpecialist, err)
+	}
+	defer tx.Rollback(ctx)
+
+	// Execute the query within the transaction
+	result, err := tx.Exec(ctx, query, args...)
+	if err != nil {
+		return fmt.Errorf("%s failed to execute mark as deleted query: %w", operationSpecialist, err)
+	}
+
+	if result.RowsAffected() == 0 {
+		return sql.ErrNoRows
+	}
+
+	// Commit transaction
+	if err := tx.Commit(ctx); err != nil {
+		return fmt.Errorf("%s failed to commit sql transaction: %w", operationSpecialist, err)
+	}
+
+	return nil
+}
+
+// GetExpiredAccounts retrieves specialists marked for deletion before the threshold time.
+func (sr *SpecialistRepositoryImpl) GetExpiredAccounts(ctx context.Context, thresholdTime time.Time) ([]domain.Specialist, error) {
+	var items []domain.Specialist
+
+	query, args, err := sq.Select("*").
+		From(currentTableName).
+		Where(sq.And{
+			sq.Eq{"is_deleted": true},
+			sq.Lt{"delete_initiated_at": thresholdTime},
+		}).
+		PlaceholderFormat(sq.Dollar).
+		ToSql()
+
+	if err != nil {
+		return nil, fmt.Errorf("%s failed to build select expired query: %w", operationSpecialist, err)
+	}
+
+	conn, err := sr.DBPool.Pool().Acquire(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("%s failed to take DB pool connection: %w", operationSpecialist, err)
+	}
+	defer conn.Release()
+
+	tx, err := conn.BeginTx(ctx, pgx.TxOptions{
+		IsoLevel:   pgx.ReadCommitted,
+		AccessMode: pgx.ReadWrite,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("%s failed to begin tx: %w", operationSpecialist, err)
+	}
+	defer tx.Rollback(ctx)
+
+	rows, err := tx.Query(ctx, query, args...)
+	if err != nil {
+		return nil, fmt.Errorf("%s failed to query expired accounts: %w", operationSpecialist, err)
+	}
+	defer rows.Close()
+
+	items, err = pgx.CollectRows(rows, pgx.RowToStructByName[domain.Specialist])
+	if err != nil {
+		return nil, fmt.Errorf("%s failed to scan expired accounts: %w", operationSpecialist, err)
+	}
+
+	return items, nil
+}
+
+// DeleteAllServices removes all service associations for a specialist.
+func (sr *SpecialistRepositoryImpl) DeleteAllServices(ctx context.Context, specialistID int64) error {
+	query, args, err := sq.Delete(serviceSpecialistTableName).
+		Where(sq.Eq{"specialist_id": specialistID}).
+		PlaceholderFormat(sq.Dollar).
+		ToSql()
+
+	if err != nil {
+		return fmt.Errorf("%s failed to build delete services query: %w", operationSpecialist, err)
+	}
+
+	conn, err := sr.DBPool.Pool().Acquire(ctx)
+	if err != nil {
+		return fmt.Errorf("%s failed to take DB pool connection: %w", operationSpecialist, err)
+	}
+	defer conn.Release()
+
+	tx, err := conn.BeginTx(ctx, pgx.TxOptions{
+		IsoLevel:   pgx.ReadCommitted,
+		AccessMode: pgx.ReadWrite,
+	})
+	if err != nil {
+		return fmt.Errorf("%s failed to begin tx: %w", operationSpecialist, err)
+	}
+	defer tx.Rollback(ctx)
+
+	_, err = tx.Exec(ctx, query, args...)
+	if err != nil {
+		return fmt.Errorf("%s failed to execute delete services: %w", operationSpecialist, err)
+	}
+
+	return tx.Commit(ctx)
+}
+
+// HardDelete permanently removes a specialist record by ID.
+func (sr *SpecialistRepositoryImpl) HardDelete(ctx context.Context, id int64) error {
+	query, args, err := sq.Delete(currentTableName).
+		Where(sq.Eq{"id": id}).
+		PlaceholderFormat(sq.Dollar).
+		ToSql()
+
+	if err != nil {
+		return fmt.Errorf("%s failed to build hard delete query: %w", operationSpecialist, err)
+	}
+
+	conn, err := sr.DBPool.Pool().Acquire(ctx)
+	if err != nil {
+		return fmt.Errorf("%s failed to take DB pool connection: %w", operationSpecialist, err)
+	}
+	defer conn.Release()
+
+	tx, err := conn.BeginTx(ctx, pgx.TxOptions{
+		IsoLevel:   pgx.ReadCommitted,
+		AccessMode: pgx.ReadWrite,
+	})
+	if err != nil {
+		return fmt.Errorf("%s failed to begin tx: %w", operationSpecialist, err)
+	}
+	defer tx.Rollback(ctx)
+
+	result, err := tx.Exec(ctx, query, args...)
+	if err != nil {
+		return fmt.Errorf("%s failed to execute hard delete: %w", operationSpecialist, err)
+	}
+
+	if result.RowsAffected() == 0 {
+		return sql.ErrNoRows
+	}
+
 	return tx.Commit(ctx)
 }

--- a/internal/repositories/pgs_specialist_repo.go
+++ b/internal/repositories/pgs_specialist_repo.go
@@ -615,7 +615,7 @@ func (sr *SpecialistRepositoryImpl) GetExpiredAccounts(ctx context.Context, thre
 
 	tx, err := conn.BeginTx(ctx, pgx.TxOptions{
 		IsoLevel:   pgx.ReadCommitted,
-		AccessMode: pgx.ReadWrite,
+		AccessMode: pgx.ReadOnly,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("%s failed to begin tx: %w", operationSpecialist, err)
@@ -631,6 +631,10 @@ func (sr *SpecialistRepositoryImpl) GetExpiredAccounts(ctx context.Context, thre
 	items, err = pgx.CollectRows(rows, pgx.RowToStructByName[domain.Specialist])
 	if err != nil {
 		return nil, fmt.Errorf("%s failed to scan expired accounts: %w", operationSpecialist, err)
+	}
+
+	if err := tx.Commit(ctx); err != nil {
+		return nil, fmt.Errorf("%s failed to commit tx: %w", operationSpecialist, err)
 	}
 
 	return items, nil


### PR DESCRIPTION
Implement specialist account deletion lifecycle

This commit introduces a robust, two-stage process for specialist account deletion, ensuring data is handled gracefully and resources are cleaned up efficiently.

Key Features
Soft Delete Endpoint (DELETE /api/v1/specialist/me):

An authenticated specialist can initiate the deletion of their own account. The system performs a "soft delete" by marking the account as is_deleted and is_active=false in the database and records the deletion timestamp. To ensure security, all of the user's active sessions are immediately revoked, and their session cookie is cleared, forcing a logout across all devices. Scheduled Hard Deletion:

A background job runs periodically to find accounts that have been in the soft-deleted state beyond the grace period (7 days). For each expired account, the system performs a comprehensive cleanup: Deletes the specialist's avatar and all portfolio images from the S3 bucket. Removes all associated service records from the database. Permanently deletes the specialist's record from the specialists table.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added specialist account deletion endpoint (soft delete) — deactivates account and revokes sessions.
  * Accounts scheduled for permanent removal after 7 days; users receive confirmation of deletion initiation.
  * Added daily background cleanup that permanently removes expired deleted accounts.

* **Documentation**
  * API docs updated to include the new delete operation and corresponding success response type.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->